### PR TITLE
Update Sisu and Guice

### DIFF
--- a/buildsupport/goodies/pom.xml
+++ b/buildsupport/goodies/pom.xml
@@ -98,6 +98,20 @@
         <groupId>org.sonatype.sisu.goodies</groupId>
         <artifactId>goodies-inject</artifactId>
         <version>${goodies.version}</version>
+        <exclusions>
+          <exclusion>
+            <groupId>org.sonatype.sisu</groupId>
+            <artifactId>sisu-guice</artifactId>
+          </exclusion>
+          <exclusion>
+            <groupId>org.sonatype.sisu.inject</groupId>
+            <artifactId>guice-assistedinject</artifactId>
+          </exclusion>
+          <exclusion>
+            <groupId>org.sonatype.sisu.inject</groupId>
+            <artifactId>guice-multibindings</artifactId>
+          </exclusion>
+        </exclusions>
       </dependency>
 
     </dependencies>

--- a/buildsupport/guice/pom.xml
+++ b/buildsupport/guice/pom.xml
@@ -28,8 +28,8 @@
   <packaging>pom</packaging>
 
   <properties>
-    <eclipse-sisu.version>0.2.0</eclipse-sisu.version>
-    <sisu-guice.version>3.1.10</sisu-guice.version>
+    <eclipse-sisu.version>0.3.3</eclipse-sisu.version>
+    <guice.version>4.0</guice.version>
   </properties>
 
   <dependencyManagement>
@@ -61,27 +61,27 @@
       </dependency>
 
       <dependency>
-        <groupId>org.sonatype.sisu</groupId>
-        <artifactId>sisu-guice</artifactId>
-        <version>${sisu-guice.version}</version>
+        <groupId>com.google.inject</groupId>
+        <artifactId>guice</artifactId>
+        <version>${guice.version}</version>
       </dependency>
 
       <dependency>
-        <groupId>org.sonatype.sisu.inject</groupId>
+        <groupId>com.google.inject.extensions</groupId>
         <artifactId>guice-servlet</artifactId>
-        <version>${sisu-guice.version}</version>
+        <version>${guice.version}</version>
       </dependency>
 
       <dependency>
-        <groupId>org.sonatype.sisu.inject</groupId>
+        <groupId>com.google.inject.extensions</groupId>
         <artifactId>guice-multibindings</artifactId>
-        <version>${sisu-guice.version}</version>
+        <version>${guice.version}</version>
       </dependency>
 
       <dependency>
-        <groupId>org.sonatype.sisu.inject</groupId>
+        <groupId>com.google.inject.extensions</groupId>
         <artifactId>guice-assistedinject</artifactId>
-        <version>${sisu-guice.version}</version>
+        <version>${guice.version}</version>
       </dependency>
 
       <dependency>

--- a/components/nexus-client-core/pom.xml
+++ b/components/nexus-client-core/pom.xml
@@ -125,8 +125,8 @@
     </dependency>
 
     <dependency>
-      <groupId>org.sonatype.sisu</groupId>
-      <artifactId>sisu-guice</artifactId>
+      <groupId>com.google.inject</groupId>
+      <artifactId>guice</artifactId>
       <optional>true</optional>
     </dependency>
 

--- a/components/nexus-core/pom.xml
+++ b/components/nexus-core/pom.xml
@@ -224,17 +224,17 @@
     </dependency>
 
     <dependency>
-      <groupId>org.sonatype.sisu</groupId>
-      <artifactId>sisu-guice</artifactId>
+      <groupId>com.google.inject</groupId>
+      <artifactId>guice</artifactId>
     </dependency>
 
     <dependency>
-      <groupId>org.sonatype.sisu.inject</groupId>
+      <groupId>com.google.inject.extensions</groupId>
       <artifactId>guice-multibindings</artifactId>
     </dependency>
 
     <dependency>
-      <groupId>org.sonatype.sisu.inject</groupId>
+      <groupId>com.google.inject.extensions</groupId>
       <artifactId>guice-assistedinject</artifactId>
     </dependency>
 

--- a/components/nexus-core/src/main/java/com/google/inject/servlet/NexusGuiceFilter.java
+++ b/components/nexus-core/src/main/java/com/google/inject/servlet/NexusGuiceFilter.java
@@ -10,7 +10,7 @@
  * of Sonatype, Inc. Apache Maven is a trademark of the Apache Software Foundation. M2eclipse is a trademark of the
  * Eclipse Foundation. All other trademarks are the property of their respective owners.
  */
-package org.sonatype.nexus.web.internal;
+package com.google.inject.servlet;
 
 import java.io.IOException;
 import java.util.Collections;
@@ -22,9 +22,6 @@ import javax.servlet.ServletContext;
 import javax.servlet.ServletException;
 import javax.servlet.ServletRequest;
 import javax.servlet.ServletResponse;
-
-import com.google.inject.servlet.FilterPipeline;
-import com.google.inject.servlet.GuiceFilter;
 
 public final class NexusGuiceFilter
     extends GuiceFilter

--- a/components/nexus-ehcache/pom.xml
+++ b/components/nexus-ehcache/pom.xml
@@ -60,8 +60,8 @@
     </dependency>
 
     <dependency>
-      <groupId>org.sonatype.sisu</groupId>
-      <artifactId>sisu-guice</artifactId>
+      <groupId>com.google.inject</groupId>
+      <artifactId>guice</artifactId>
       <scope>provided</scope>
     </dependency>
 

--- a/components/nexus-security/pom.xml
+++ b/components/nexus-security/pom.xml
@@ -44,8 +44,8 @@
     </dependency>
 
     <dependency>
-      <groupId>org.sonatype.sisu</groupId>
-      <artifactId>sisu-guice</artifactId>
+      <groupId>com.google.inject</groupId>
+      <artifactId>guice</artifactId>
     </dependency>
 
     <dependency>
@@ -79,7 +79,7 @@
     </dependency>
 
     <dependency>
-      <groupId>org.sonatype.sisu.inject</groupId>
+      <groupId>com.google.inject.extensions</groupId>
       <artifactId>guice-multibindings</artifactId>
     </dependency>
 
@@ -120,7 +120,7 @@
     </dependency>
 
     <dependency>
-      <groupId>org.sonatype.sisu.inject</groupId>
+      <groupId>com.google.inject.extensions</groupId>
       <artifactId>guice-servlet</artifactId>
     </dependency>
 

--- a/components/nexus-webapp/src/main/webapp/WEB-INF/web.xml
+++ b/components/nexus-webapp/src/main/webapp/WEB-INF/web.xml
@@ -26,7 +26,7 @@
   
   <filter>
     <filter-name>guiceFilter</filter-name>
-    <filter-class>org.sonatype.nexus.web.internal.NexusGuiceFilter</filter-class>
+    <filter-class>com.google.inject.servlet.NexusGuiceFilter</filter-class>
   </filter>
 
   <filter-mapping>

--- a/plugins/basic/nexus-content-plugin/src/main/java/org/sonatype/nexus/content/internal/ContentServlet.java
+++ b/plugins/basic/nexus-content-plugin/src/main/java/org/sonatype/nexus/content/internal/ContentServlet.java
@@ -162,7 +162,7 @@ public class ContentServlet
       resourceStorePath = "/";
     }
     final ResourceStoreRequest result = new ResourceStoreRequest(resourceStorePath);
-    result.getRequestContext().put(STOPWATCH_KEY, new Stopwatch().start());
+    result.getRequestContext().put(STOPWATCH_KEY, Stopwatch.createStarted());
 
     // stuff in the user id if we have it in request
     final Subject subject = SecurityUtils.getSubject();

--- a/plugins/capabilities/nexus-capabilities-client/pom.xml
+++ b/plugins/capabilities/nexus-capabilities-client/pom.xml
@@ -34,8 +34,8 @@
     </dependency>
 
     <dependency>
-      <groupId>org.sonatype.sisu</groupId>
-      <artifactId>sisu-guice</artifactId>
+      <groupId>com.google.inject</groupId>
+      <artifactId>guice</artifactId>
     </dependency>
 
     <dependency>

--- a/plugins/restlet1x/nexus-restlet1x-plugin/src/main/java/org/sonatype/nexus/restlet1x/internal/RestletServletModule.java
+++ b/plugins/restlet1x/nexus-restlet1x-plugin/src/main/java/org/sonatype/nexus/restlet1x/internal/RestletServletModule.java
@@ -16,9 +16,9 @@ import java.util.HashMap;
 import java.util.Map;
 
 import org.sonatype.nexus.web.internal.CookieFilter;
-import org.sonatype.nexus.web.internal.NexusGuiceFilter;
 import org.sonatype.nexus.web.internal.SecurityFilter;
 
+import com.google.inject.servlet.NexusGuiceFilter;
 import com.google.inject.servlet.ServletModule;
 
 /**

--- a/testsupport/nexus-test-common/pom.xml
+++ b/testsupport/nexus-test-common/pom.xml
@@ -33,8 +33,8 @@
     </dependency>
 
     <dependency>
-      <groupId>org.sonatype.sisu</groupId>
-      <artifactId>sisu-guice</artifactId>
+      <groupId>com.google.inject</groupId>
+      <artifactId>guice</artifactId>
     </dependency>
 
     <dependency>


### PR DESCRIPTION
Changes:
* sisu bump to 0.3.3
* guice bump/change to google 4.0
* smaller code changes (deprecated/removed method use and https://github.com/google/guice/issues/618 related)

This PR updates Sisu and Guice (to "vanilla" Guice), and hence, among other improvements makes possible to use Plugins developed using Java8 target (Sisu 0.2.x is unable to scan Java8 bytecode).