### PR TITLE
Remove size check for prefix file

### DIFF
--- a/components/nexus-core/src/main/java/org/sonatype/nexus/proxy/maven/routing/Config.java
+++ b/components/nexus-core/src/main/java/org/sonatype/nexus/proxy/maven/routing/Config.java
@@ -73,13 +73,5 @@ public interface Config
    *
    * @return the maximum allowed prefix file entry length.
    */
-  public int getPrefixFileMaxLineLength();
-
-  /**
-   * Returns the maximum allowed file size for prefix file (in bytes). File being bigger than allowed file size will
-   * be refused to be loaded up.
-   *
-   * @return the maximum allowed file size for prefix file, in bytes.
-   */
-  public int getPrefixFileMaxSize();
+  int getPrefixFileMaxLineLength();
 }

--- a/components/nexus-core/src/main/java/org/sonatype/nexus/proxy/maven/routing/internal/ConfigImpl.java
+++ b/components/nexus-core/src/main/java/org/sonatype/nexus/proxy/maven/routing/internal/ConfigImpl.java
@@ -66,9 +66,6 @@ public class ConfigImpl
   private static final int PREFIX_FILE_MAX_LINE_LENGTH = SystemPropertiesHelper.getInteger(Config.class.getName()
       + ".prefixFileMaxLineLength", 250); // 250 chars
 
-  private static final int PREFIX_FILE_MAX_SIZE = SystemPropertiesHelper.getInteger(Config.class.getName()
-      + ".prefixFileMaxSize", 100000); // 100 KB
-
   private final boolean featureActive;
 
   /**
@@ -119,10 +116,4 @@ public class ConfigImpl
   public int getPrefixFileMaxLineLength() {
     return PREFIX_FILE_MAX_LINE_LENGTH;
   }
-
-  @Override
-  public int getPrefixFileMaxSize() {
-    return PREFIX_FILE_MAX_SIZE;
-  }
-
 }

--- a/components/nexus-core/src/main/java/org/sonatype/nexus/proxy/maven/routing/internal/TextFilePrefixSourceMarshaller.java
+++ b/components/nexus-core/src/main/java/org/sonatype/nexus/proxy/maven/routing/internal/TextFilePrefixSourceMarshaller.java
@@ -72,8 +72,6 @@ public class TextFilePrefixSourceMarshaller
    */
   protected static final String UNSUPPORTED = "@ unsupported";
 
-  private final int prefixFileMaxSize;
-
   private final int prefixFileMaxLineLength;
 
   private final int prefixFileMaxEntryCount;
@@ -104,10 +102,8 @@ public class TextFilePrefixSourceMarshaller
    * @param config the autorouting config.
    */
   public TextFilePrefixSourceMarshaller(final Config config) {
-    checkArgument(config.getPrefixFileMaxSize() > 0);
     checkArgument(config.getPrefixFileMaxLineLength() > 0);
     checkArgument(config.getPrefixFileMaxEntriesCount() > 0);
-    this.prefixFileMaxSize = config.getPrefixFileMaxSize();
     this.prefixFileMaxLineLength = config.getPrefixFileMaxLineLength();
     this.prefixFileMaxEntryCount = config.getPrefixFileMaxEntriesCount();
   }
@@ -137,10 +133,6 @@ public class TextFilePrefixSourceMarshaller
   public final Result read(final StorageFileItem file)
       throws InvalidInputException, IOException
   {
-    if (file.getLength() > prefixFileMaxSize) {
-      throw new InvalidInputException("Prefix file size exceeds maximum allowed size (" + prefixFileMaxSize
-          + "), refusing to load it.");
-    }
     Closer closer = Closer.create();
     try {
       final BufferedReader reader =


### PR DESCRIPTION
As there is already max lines and max line length checks (that implicitly
caps the file size), hence, instead of setting two properties in future
(entry count and/or file size) it is enough to increase max entry count.

Current prefix file stats:
size: 101kb
lines: 7258