### PR TITLE
NEXUS-10987 - Hard dependency on Oracle JRE

### DIFF
--- a/components/nexus-core/src/main/java/org/sonatype/nexus/apachehttpclient/NexusSSLConnectionSocketFactory.java
+++ b/components/nexus-core/src/main/java/org/sonatype/nexus/apachehttpclient/NexusSSLConnectionSocketFactory.java
@@ -129,11 +129,11 @@ public class NexusSSLConnectionSocketFactory
         Method setHost = sslSocketFactoryClass.getMethod("setHost", String.class);
         setHost.invoke(sock, host.getHostName());
       } catch (NoSuchMethodException e1) {
-        e1.printStackTrace();
+        // do nothing - means old JRE
       } catch (InvocationTargetException e1) {
-        e1.printStackTrace();
+        // do nothing - should never happen
       } catch (IllegalAccessException e1) {
-        e1.printStackTrace();
+        // do nothing - should never happen
       }
     }
     try {

--- a/components/nexus-core/src/main/java/org/sonatype/nexus/apachehttpclient/NexusSSLConnectionSocketFactory.java
+++ b/components/nexus-core/src/main/java/org/sonatype/nexus/apachehttpclient/NexusSSLConnectionSocketFactory.java
@@ -1,6 +1,6 @@
 /*
  * Sonatype Nexus (TM) Open Source Version
- * Copyright (c) 2008-2015 Sonatype, Inc.
+ * Copyright (c) 2008-present Sonatype, Inc.
  * All rights reserved. Includes the third-party code listed at http://links.sonatype.com/products/nexus/oss/attributions.
  *
  * This program and the accompanying materials are made available under the terms of the Eclipse Public License Version 1.0,
@@ -33,7 +33,6 @@ import org.apache.http.conn.socket.LayeredConnectionSocketFactory;
 import org.apache.http.conn.ssl.X509HostnameVerifier;
 import org.apache.http.protocol.HttpContext;
 import org.codehaus.mojo.animal_sniffer.IgnoreJRERequirement;
-//import sun.security.ssl.SSLSocketImpl;
 
 import static com.google.common.base.Preconditions.checkNotNull;
 


### PR DESCRIPTION
When using a HTTPS proxy repository on a JRE with an alternative JSSE implementation (like the IBM JRE), the use of sun.security.ssl.SSLSocketImpl leads to a NoClassDefFoundError.

This makes HTTPS unusable for proxy repositories on these JREs.
The change removes the dependency on the Oracle JRE by using reflection to access sun.security.ssl.SSLSocketImpl.

This PR implements the quick fix suggested in [NEXUS-10987](https://issues.sonatype.org/browse/NEXUS-10987)
