### PR TITLE
ConfigDir is ${karaf.etc}, not ${karaf.base}/etc

### DIFF
--- a/components/nexus-base/src/main/java/org/sonatype/nexus/internal/app/ApplicationDirectoriesImpl.java
+++ b/components/nexus-base/src/main/java/org/sonatype/nexus/internal/app/ApplicationDirectoriesImpl.java
@@ -47,12 +47,13 @@ public class ApplicationDirectoriesImpl
 
   @Inject
   public ApplicationDirectoriesImpl(@Named("${karaf.base}") final File installDir,
-                                    @Named("${karaf.data}") final File workDir)
+                                    @Named("${karaf.data}") final File workDir,
+                                    @Named("${karaf.etc}") final File configDir)
   {
     this.installDir = resolve(installDir, false);
     log.debug("Install dir: {}", this.installDir);
 
-    this.configDir = resolve(new File(installDir, "etc"), false);
+    this.configDir = resolve(configDir, false);
     log.debug("Config dir: {}", this.configDir);
 
     this.workDir = resolve(workDir, true);

--- a/components/nexus-base/src/main/java/org/sonatype/nexus/internal/log/LogbackLoggerOverrides.java
+++ b/components/nexus-base/src/main/java/org/sonatype/nexus/internal/log/LogbackLoggerOverrides.java
@@ -62,7 +62,7 @@ public class LogbackLoggerOverrides
   @Inject
   public LogbackLoggerOverrides(final ApplicationDirectories applicationDirectories) {
     checkNotNull(applicationDirectories);
-    this.file = new File(applicationDirectories.getWorkDirectory("etc/logback"), "logback-overrides.xml");
+    this.file = new File(applicationDirectories.getConfigDirectory("logback"), "logback-overrides.xml");
     log.info("File: {}", file);
   }
 


### PR DESCRIPTION
ConfigDir is being resolved through ${karaf.base} variable, but system allows to config ${karaf.etc} in a completa and unrelated directory. That's the correct, especially if you are willing to apply FHS (Filesystem Hierarchy Standard) and put karaf/etc in /etc/opt (and karaf.base in /opt). Such deployment scenarios (configuration in a different place than data and binaries) need respect scrupulously the karaf variables.