### PR TITLE
Nexus 2.x lower noise

### DIFF
--- a/components/nexus-core/src/main/java/org/sonatype/nexus/proxy/repository/AbstractProxyRepository.java
+++ b/components/nexus-core/src/main/java/org/sonatype/nexus/proxy/repository/AbstractProxyRepository.java
@@ -1463,7 +1463,7 @@ public abstract class AbstractProxyRepository
                 t = e;
               }
 
-              log.warn(
+              log.debug(
                   String.format(
                       "Got RemoteStorageException in proxy repository %s while retrieving remote artifact \"%s\" from URL %s, this is %s (re)try, cause: %s: %s",
                       RepositoryStringUtils.getHumanizedNameString(this), request.toString(),
@@ -1487,7 +1487,7 @@ public abstract class AbstractProxyRepository
                 t = e;
               }
 
-              log.warn(
+              log.debug(
                   "Got LocalStorageException in proxy repository {} while caching retrieved artifact \"{}\" got from URL {}, this is {} (re)try",
                   RepositoryStringUtils.getHumanizedNameString(this),
                   request,

--- a/components/nexus-core/src/main/java/org/sonatype/nexus/proxy/repository/AbstractProxyRepository.java
+++ b/components/nexus-core/src/main/java/org/sonatype/nexus/proxy/repository/AbstractProxyRepository.java
@@ -1463,7 +1463,7 @@ public abstract class AbstractProxyRepository
                 t = e;
               }
 
-              log.error(
+              log.warn(
                   String.format(
                       "Got RemoteStorageException in proxy repository %s while retrieving remote artifact \"%s\" from URL %s, this is %s (re)try, cause: %s: %s",
                       RepositoryStringUtils.getHumanizedNameString(this), request.toString(),
@@ -1487,7 +1487,7 @@ public abstract class AbstractProxyRepository
                 t = e;
               }
 
-              log.error(
+              log.warn(
                   "Got LocalStorageException in proxy repository {} while caching retrieved artifact \"{}\" got from URL {}, this is {} (re)try",
                   RepositoryStringUtils.getHumanizedNameString(this),
                   request,


### PR DESCRIPTION
Try to be consistent with logging and failures. Here, retry happens,
hence no need to litter logs with ERRORs.

Useful if monitoring ERROR log rates triggers some alarms, given these lines are very often present but does not actually mean ERRORs.
