### PR TITLE
NEXUS-4001: NX2 generates wrong plugin prefix

### DIFF
--- a/components/nexus-core/src/main/java/org/sonatype/nexus/proxy/maven/metadata/AbstractMetadataHelper.java
+++ b/components/nexus-core/src/main/java/org/sonatype/nexus/proxy/maven/metadata/AbstractMetadataHelper.java
@@ -284,7 +284,6 @@ abstract public class AbstractMetadataHelper
                   new XmlPlexusConfiguration(Xpp3DomBuilder.build(new InputStreamReader(zip)));
 
               prefix = plexusConfig.getChild("goalPrefix").getValue();
-              zip.closeEntry();
               break;
             }
             zip.closeEntry();


### PR DESCRIPTION
There was an erroneous closeEntry call, while Xpp3DomBuilder
closes the zip stream itself, that made the try-with-resource
always fail, when prefix was read from XML.