### PR TITLE
Update Jackson

### DIFF
--- a/buildsupport/rest/pom.xml
+++ b/buildsupport/rest/pom.xml
@@ -29,7 +29,7 @@
 
   <properties>
     <siesta.version>1.7</siesta.version>
-    <jackson.version>2.3.1</jackson.version>
+    <jackson.version>2.8.5</jackson.version>
   </properties>
 
   <dependencyManagement>
@@ -149,10 +149,15 @@
 
       <dependency>
         <groupId>com.fasterxml.jackson.jaxrs</groupId>
-        <artifactId>jackson-jaxrs-smile-provider</artifactId>
-        <version>${jackson2.version}</version>
+        <artifactId>jackson-jaxrs-json-provider</artifactId>
+        <version>${jackson.version}</version>
       </dependency>
 
+      <dependency>
+        <groupId>com.fasterxml.jackson.module</groupId>
+        <artifactId>jackson-module-jaxb-annotations</artifactId>
+        <version>${jackson.version}</version>
+      </dependency>
     </dependencies>
   </dependencyManagement>
 


### PR DESCRIPTION
Given due to half-ass OSGi integration, plugin cannot override core dependency
anymore, and Jackson update is really trivial (yup, thats al), bump Jackson
instead. This makes your life easier, in cases you have a plugin that depends on
new(er) Jackson that the ancient included in NX core, like Elasticsearch plugin
might be for example.