### PR TITLE
Auto-role plugin

### DIFF
--- a/assemblies/nexus-core-feature/pom.xml
+++ b/assemblies/nexus-core-feature/pom.xml
@@ -75,6 +75,13 @@
 
     <dependency>
       <groupId>org.sonatype.nexus.plugins</groupId>
+      <artifactId>nexus-autorole-plugin</artifactId>
+      <classifier>features</classifier>
+      <type>xml</type>
+    </dependency>
+
+    <dependency>
+      <groupId>org.sonatype.nexus.plugins</groupId>
       <artifactId>nexus-ssl-plugin</artifactId>
       <classifier>features</classifier>
       <type>xml</type>

--- a/assemblies/nexus-core-feature/src/main/feature/feature.xml
+++ b/assemblies/nexus-core-feature/src/main/feature/feature.xml
@@ -16,6 +16,7 @@
 <features xmlns="http://karaf.apache.org/xmlns/features/v1.2.1" name="${project.artifactId}">
   <feature name="${project.artifactId}">
     <feature>nexus-audit-plugin</feature>
+    <feature>nexus-autorole-plugin</feature>
     <feature>nexus-ssl-plugin</feature>
     <feature>nexus-coreui-plugin</feature>
     <feature>nexus-repository-httpbridge</feature>

--- a/components/nexus-security/src/main/java/org/sonatype/nexus/security/anonymous/AnonymousHelper.java
+++ b/components/nexus-security/src/main/java/org/sonatype/nexus/security/anonymous/AnonymousHelper.java
@@ -14,6 +14,7 @@ package org.sonatype.nexus.security.anonymous;
 
 import javax.annotation.Nullable;
 
+import org.apache.shiro.subject.PrincipalCollection;
 import org.apache.shiro.subject.Subject;
 
 /**
@@ -32,5 +33,14 @@ public class AnonymousHelper
    */
   public static boolean isAnonymous(@Nullable final Subject subject) {
     return subject != null && subject.getPrincipals() instanceof AnonymousPrincipalCollection;
+  }
+
+  /**
+   * Check given given principals represent anonymous.
+   *
+   * @since 3.2
+   */
+  public static boolean isAnonymous(@Nullable final PrincipalCollection principals) {
+    return principals instanceof AnonymousPrincipalCollection;
   }
 }

--- a/plugins/nexus-autorole-plugin/pom.xml
+++ b/plugins/nexus-autorole-plugin/pom.xml
@@ -1,0 +1,53 @@
+<!--
+
+    Sonatype Nexus (TM) Open Source Version
+    Copyright (c) 2008-present Sonatype, Inc.
+    All rights reserved. Includes the third-party code listed at http://links.sonatype.com/products/nexus/oss/attributions.
+
+    This program and the accompanying materials are made available under the terms of the Eclipse Public License Version 1.0,
+    which accompanies this distribution and is available at http://www.eclipse.org/legal/epl-v10.html.
+
+    Sonatype Nexus (TM) Professional Version is available from Sonatype, Inc. "Sonatype" and "Sonatype Nexus" are trademarks
+    of Sonatype, Inc. Apache Maven is a trademark of the Apache Software Foundation. M2eclipse is a trademark of the
+    Eclipse Foundation. All other trademarks are the property of their respective owners.
+
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>org.sonatype.nexus.plugins</groupId>
+    <artifactId>nexus-plugins</artifactId>
+    <version>3.2.0-SNAPSHOT</version>
+  </parent>
+
+  <artifactId>nexus-autorole-plugin</artifactId>
+  <name>${project.groupId}:${project.artifactId}</name>
+  <packaging>bundle</packaging>
+
+  <dependencies>
+    <dependency>
+      <groupId>org.sonatype.nexus</groupId>
+      <artifactId>nexus-plugin-api</artifactId>
+      <scope>provided</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>org.sonatype.nexus</groupId>
+      <artifactId>nexus-test-common</artifactId>
+      <scope>test</scope>
+    </dependency>
+  </dependencies>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.karaf.tooling</groupId>
+        <artifactId>karaf-maven-plugin</artifactId>
+      </plugin>
+    </plugins>
+  </build>
+
+</project>

--- a/plugins/nexus-autorole-plugin/src/main/java/org/sonatype/nexus/autorole/internal/AutoRoleCapability.groovy
+++ b/plugins/nexus-autorole-plugin/src/main/java/org/sonatype/nexus/autorole/internal/AutoRoleCapability.groovy
@@ -1,0 +1,150 @@
+package org.sonatype.nexus.autorole.internal
+
+import javax.inject.Inject
+import javax.inject.Named
+import javax.inject.Singleton
+
+import org.sonatype.goodies.i18n.I18N
+import org.sonatype.goodies.i18n.MessageBundle
+import org.sonatype.goodies.i18n.MessageBundle.DefaultMessage
+import org.sonatype.nexus.capability.CapabilityConfigurationSupport
+import org.sonatype.nexus.capability.CapabilityDescriptorSupport
+import org.sonatype.nexus.capability.CapabilitySupport
+import org.sonatype.nexus.capability.CapabilityType
+import org.sonatype.nexus.capability.Capability
+import org.sonatype.nexus.capability.Condition
+import org.sonatype.nexus.formfields.ComboboxFormField
+import org.sonatype.nexus.formfields.FormField
+import org.sonatype.nexus.security.realm.RealmManager
+
+import groovy.transform.PackageScope
+import groovy.transform.ToString
+
+import static org.sonatype.nexus.capability.CapabilityType.capabilityType
+
+/**
+ * Automatic role {@link Capability}.
+ *
+ * @since 3.2
+ */
+@Named(AutoRoleCapability.TYPE_ID)
+class AutoRoleCapability
+  extends CapabilitySupport<Configuration> {
+  public static final String TYPE_ID = 'autorole'
+
+  public static final CapabilityType TYPE = capabilityType(TYPE_ID)
+
+  private static interface Messages
+    extends MessageBundle
+  {
+    @DefaultMessage('Automatic Role')
+    String name()
+
+    @DefaultMessage('Role')
+    String roleLabel()
+
+    @DefaultMessage('The role which is automatically granted to authenticated users')
+    String roleHelp()
+
+    @DefaultMessage('%s')
+    String description(String role)
+  }
+
+  @PackageScope
+  static final Messages messages = I18N.create(Messages.class)
+
+  @Inject
+  RealmManager realmManager
+
+  @Inject
+  AutoRoleRealm realm
+
+  @Override
+  protected Configuration createConfig(final Map<String, String> properties) {
+    return new Configuration(properties)
+  }
+
+  @Override
+  protected String renderDescription() {
+    return messages.description(config.role)
+  }
+
+  @Override
+  Condition activationCondition() {
+    return conditions().capabilities().passivateCapabilityDuringUpdate()
+  }
+
+  @Override
+  protected void onActivate(final Configuration config) {
+    realm.role = config.role
+
+    // install realm if needed
+    realmManager.enableRealm(AutoRoleRealm.NAME)
+  }
+
+  @Override
+  protected void onPassivate(final Configuration config) {
+    realm.role = null
+  }
+
+  //
+  // Configuration
+  //
+
+  private static final String P_ROLE = 'role'
+
+  @ToString(includePackage = false, includeNames = true)
+  static class Configuration
+    extends CapabilityConfigurationSupport
+  {
+    String role
+
+    Configuration(final Map<String, String> properties) {
+      role = parseUri(properties[P_ROLE])
+    }
+  }
+
+  //
+  // Descriptor
+  //
+
+  @Named(AutoRoleCapability.TYPE_ID)
+  @Singleton
+  static class Descriptor
+    extends CapabilityDescriptorSupport
+  {
+    private final FormField role
+
+    Descriptor() {
+      this.exposed = true
+      this.hidden = false
+
+      this.role = new ComboboxFormField<String>(
+        P_ROLE,
+        messages.roleLabel(),
+        messages.roleHelp(),
+        FormField.MANDATORY
+      ).withStoreApi('coreui_Role.read')
+    }
+
+    @Override
+    CapabilityType type() {
+      return TYPE
+    }
+
+    @Override
+    String name() {
+      return messages.name()
+    }
+
+    @Override
+    List<FormField> formFields() {
+      return [role]
+    }
+
+    @Override
+    protected String renderAbout() {
+      return render("$TYPE_ID-about.vm")
+    }
+  }
+}

--- a/plugins/nexus-autorole-plugin/src/main/java/org/sonatype/nexus/autorole/internal/AutoRoleRealm.java
+++ b/plugins/nexus-autorole-plugin/src/main/java/org/sonatype/nexus/autorole/internal/AutoRoleRealm.java
@@ -1,0 +1,77 @@
+package org.sonatype.nexus.autorole.internal;
+
+import com.google.common.annotations.VisibleForTesting;
+import org.apache.shiro.authc.AuthenticationException;
+import org.apache.shiro.authc.AuthenticationInfo;
+import org.apache.shiro.authc.AuthenticationToken;
+import org.apache.shiro.authz.AuthorizationInfo;
+import org.apache.shiro.authz.SimpleAuthorizationInfo;
+import org.apache.shiro.realm.AuthorizingRealm;
+import org.apache.shiro.subject.PrincipalCollection;
+import org.eclipse.sisu.Description;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.sonatype.nexus.security.anonymous.AnonymousHelper;
+
+import javax.annotation.Nullable;
+import javax.inject.Named;
+import javax.inject.Singleton;
+
+/**
+ * Automatic role {@link AuthorizingRealm}.
+ *
+ * @since 3.2
+ */
+@Named(AutoRoleRealm.NAME)
+@Singleton
+@Description("Automatic Role")
+public class AutoRoleRealm
+  extends AuthorizingRealm
+{
+  private static final Logger log = LoggerFactory.getLogger(AutoRoleRealm.class);
+
+  public static final String NAME = "AutoRole";
+
+  @Nullable
+  private String role;
+
+  @Nullable
+  public String getRole() {
+    return role;
+  }
+
+  public void setRole(@Nullable final String role) {
+    this.role = role;
+  }
+
+  @Override
+  protected AuthorizationInfo doGetAuthorizationInfo(final PrincipalCollection principals) {
+    return maybeGrantRole(principals);
+  }
+
+  // TODO: sort out if this logic is needed for NX3 that has different anonymous handling that NX2 which this is ported from
+
+  @VisibleForTesting
+  @Nullable
+  AuthorizationInfo maybeGrantRole(final PrincipalCollection principals) {
+    if (role != null) {
+      // only attempt to apply auto-role if user is not anonymous
+      if (!AnonymousHelper.isAnonymous(principals)) {
+        SimpleAuthorizationInfo info = new SimpleAuthorizationInfo();
+        info.addRole(role);
+        log.debug("Granting {} role to {}", role, principals);
+        return info;
+      }
+    }
+
+    return null;
+  }
+
+  /**
+   * @throws UnsupportedOperationException  Authentication is not supported
+   */
+  @Override
+  protected AuthenticationInfo doGetAuthenticationInfo(final AuthenticationToken token) throws AuthenticationException {
+    throw new UnsupportedOperationException();
+  }
+}

--- a/plugins/nexus-autorole-plugin/src/main/resources/org/sonatype/nexus/autorole/internal/autorole-about.vm
+++ b/plugins/nexus-autorole-plugin/src/main/resources/org/sonatype/nexus/autorole/internal/autorole-about.vm
@@ -1,0 +1,3 @@
+<p>
+  Automatically grants a role to <em>authenticated</em> users.
+</p>

--- a/plugins/nexus-autorole-plugin/src/test/java/org/sonatype/nexus/autorole/internal/AutoRoleRealmTest.groovy
+++ b/plugins/nexus-autorole-plugin/src/test/java/org/sonatype/nexus/autorole/internal/AutoRoleRealmTest.groovy
@@ -1,0 +1,53 @@
+package org.sonatype.nexus.autorole.internal
+
+import org.sonatype.goodies.testsupport.TestSupport
+import org.sonatype.nexus.security.anonymous.AnonymousPrincipalCollection
+
+import org.apache.shiro.authz.AuthorizationInfo
+import org.apache.shiro.subject.PrincipalCollection
+import org.apache.shiro.subject.SimplePrincipalCollection
+import org.junit.Before
+import org.junit.Test
+
+/**
+ * Tests for {@link AutoRoleRealm}.
+ */
+class AutoRoleRealmTest
+  extends TestSupport
+{
+  private AutoRoleRealm underTest
+
+  @Before
+  void setUp() {
+    underTest = new AutoRoleRealm()
+  }
+
+  private static PrincipalCollection principals(final String userId) {
+    if (userId == 'anonymous') {
+      return new AnonymousPrincipalCollection(userId, 'realm')
+    }
+    return new SimplePrincipalCollection(userId, 'realm')
+  }
+
+  @Test
+  void 'when not configured nothing is granted'() {
+    underTest.role = null
+    AuthorizationInfo info = underTest.maybeGrantRole(principals('test'))
+    assert info == null
+  }
+
+  @Test
+  void 'role granted when user is authenticated'() {
+    underTest.role = 'default-role'
+    AuthorizationInfo info = underTest.maybeGrantRole(principals('test'))
+    assert info != null
+    assert info.roles.contains('default-role')
+  }
+
+  @Test
+  void 'role not granted for anonymous'() {
+    underTest.role = 'default-role'
+    AuthorizationInfo info = underTest.maybeGrantRole(principals('anonymous'))
+    assert info == null
+  }
+}

--- a/plugins/pom.xml
+++ b/plugins/pom.xml
@@ -30,6 +30,7 @@
 
   <modules>
     <module>nexus-audit-plugin</module>
+    <module>nexus-autorole-plugin</module>
     <module>nexus-coreui-plugin</module>
     <module>nexus-repository-httpbridge</module>
     <module>nexus-repository-maven</module>
@@ -64,6 +65,22 @@
       <dependency>
         <groupId>org.sonatype.nexus.plugins</groupId>
         <artifactId>nexus-audit-plugin</artifactId>
+        <version>3.2.0-SNAPSHOT</version>
+        <classifier>features</classifier>
+        <type>xml</type>
+      </dependency>
+
+      <!-- autorole -->
+
+      <dependency>
+        <groupId>org.sonatype.nexus.plugins</groupId>
+        <artifactId>nexus-autorole-plugin</artifactId>
+        <version>3.2.0-SNAPSHOT</version>
+      </dependency>
+
+      <dependency>
+        <groupId>org.sonatype.nexus.plugins</groupId>
+        <artifactId>nexus-autorole-plugin</artifactId>
         <version>3.2.0-SNAPSHOT</version>
         <classifier>features</classifier>
         <type>xml</type>


### PR DESCRIPTION
Adds autorole plugin which can automatically grant all authenticated users a specific role.

This is useful in environments where its not feasible to use directory-services to provide a sane base role for all authenticated users.