### PR TITLE
Fix NEXUS-16492: incompatibility with windows containers.

### DIFF
--- a/components/nexus-blobstore-file/src/main/java/org/sonatype/nexus/blobstore/file/internal/BlobStoreMetricsStoreImpl.java
+++ b/components/nexus-blobstore-file/src/main/java/org/sonatype/nexus/blobstore/file/internal/BlobStoreMetricsStoreImpl.java
@@ -156,7 +156,7 @@ public class BlobStoreMetricsStoreImpl
 
   private long getAvailableSpace() {
     try {
-      return Files.getFileStore(storageDirectory).getUsableSpace();
+      return storageDirectory.toFile().getUsableSpace();
     }
     catch (Exception e) {
       throw new RuntimeException(e);


### PR DESCRIPTION
Changed `getAvailableSpace()` implementation to fix incompatiblity with windows containers.
When run in a windows containerized environment, JDK function `Files.getFileStore(storageDirectory)` throws an exception (_java.nio.file.NoSuchFileException_).

