### PR TITLE
plugins: nexus-blobstore-s3: allow to use force_path_style access to bucket.

### DIFF
--- a/plugins/nexus-blobstore-s3/src/main/java/org/sonatype/nexus/blobstore/s3/internal/AmazonS3Factory.java
+++ b/plugins/nexus-blobstore-s3/src/main/java/org/sonatype/nexus/blobstore/s3/internal/AmazonS3Factory.java
@@ -42,6 +42,7 @@ import static org.sonatype.nexus.blobstore.s3.internal.S3BlobStore.REGION_KEY;
 import static org.sonatype.nexus.blobstore.s3.internal.S3BlobStore.SECRET_ACCESS_KEY_KEY;
 import static org.sonatype.nexus.blobstore.s3.internal.S3BlobStore.SESSION_TOKEN_KEY;
 import static org.sonatype.nexus.blobstore.s3.internal.S3BlobStore.SIGNERTYPE_KEY;
+import static org.sonatype.nexus.blobstore.s3.internal.S3BlobStore.FORCE_PATH_STYLE_KEY;
 
 /**
  * Creates configured AmazonS3 clients.
@@ -61,6 +62,7 @@ public class AmazonS3Factory
     String secretAccessKey = blobStoreConfiguration.attributes(CONFIG_KEY).get(SECRET_ACCESS_KEY_KEY, String.class);
     String region = blobStoreConfiguration.attributes(CONFIG_KEY).get(REGION_KEY, String.class);
     String signerType = blobStoreConfiguration.attributes(CONFIG_KEY).get(SIGNERTYPE_KEY, String.class);
+    String forcePathStyle = blobStoreConfiguration.attributes(CONFIG_KEY).get(FORCE_PATH_STYLE_KEY, String.class);
 
     if (!isNullOrEmpty(accessKeyId) && !isNullOrEmpty(secretAccessKey)) {
       String sessionToken = blobStoreConfiguration.attributes(CONFIG_KEY).get(SESSION_TOKEN_KEY, String.class);
@@ -85,6 +87,10 @@ public class AmazonS3Factory
       ClientConfiguration clientConfiguration = PredefinedClientConfigurations.defaultConfig();
       clientConfiguration.setSignerOverride(signerType);
       builder = builder.withClientConfiguration(clientConfiguration);
+    }
+
+    if (!isNullOrEmpty(forcePathStyle)) {
+      builder = builder.withPathStyleAccessEnabled(forcePathStyle.equals("true"));
     }
 
     return builder.build();

--- a/plugins/nexus-blobstore-s3/src/main/java/org/sonatype/nexus/blobstore/s3/internal/S3BlobStore.java
+++ b/plugins/nexus-blobstore-s3/src/main/java/org/sonatype/nexus/blobstore/s3/internal/S3BlobStore.java
@@ -110,6 +110,8 @@ public class S3BlobStore
 
   public static final String SIGNERTYPE_KEY = "signertype";
 
+  public static final String FORCE_PATH_STYLE_KEY = "forcepathstyle";
+
   public static final String BUCKET_REGEX =
       "^([a-z]|(\\d(?!\\d{0,2}\\.\\d{1,3}\\.\\d{1,3}\\.\\d{1,3})))([a-z\\d]|(\\.(?!(\\.|-)))|(-(?!\\.))){1,61}[a-z\\d]$";
 

--- a/plugins/nexus-blobstore-s3/src/main/java/org/sonatype/nexus/blobstore/s3/internal/S3BlobStoreDescriptor.java
+++ b/plugins/nexus-blobstore-s3/src/main/java/org/sonatype/nexus/blobstore/s3/internal/S3BlobStoreDescriptor.java
@@ -96,6 +96,12 @@ public class S3BlobStoreDescriptor
 
     @DefaultMessage("An API signature version which may be required for third party object stores using the S3 API")
     String signerTypeHelp();
+
+    @DefaultMessage("Configures the client to use path-style access")
+    String forcePathStyleLabel();
+
+    @DefaultMessage("Setting this flag will result in path-style access being used for all requests")
+    String forcePathStyleHelp();
   }
 
   private static final Messages messages = I18N.create(Messages.class);
@@ -109,6 +115,7 @@ public class S3BlobStoreDescriptor
   private final FormField endpoint;
   private final FormField expiration;
   private final FormField signerType;
+  private final FormField forcePathStyle;
 
   public S3BlobStoreDescriptor() {
     this.bucket = new StringTextFormField(
@@ -171,6 +178,13 @@ public class S3BlobStoreDescriptor
         AmazonS3Factory.DEFAULT
     ).withStoreApi("s3_S3.signertypes");
     this.signerType.getAttributes().put("sortProperty", "order");
+    this.forcePathStyle = new ComboboxFormField<String>(
+        S3BlobStore.FORCE_PATH_STYLE_KEY,
+        messages.forcePathStyleLabel(),
+        messages.forcePathStyleHelp(),
+        FormField.MANDATORY
+    ).withStoreApi("s3_S3.forcepathstyles").withInitialValue("false");
+
   }
 
   @Override
@@ -181,6 +195,6 @@ public class S3BlobStoreDescriptor
   @Override
   public List<FormField> getFormFields() {
     return Arrays.asList(bucket, accessKeyId, secretAccessKey, sessionToken, assumeRole, region, endpoint,
-        expiration, signerType);
+        expiration, signerType, forcePathStyle);
   }
 }

--- a/plugins/nexus-blobstore-s3/src/main/java/org/sonatype/nexus/blobstore/s3/internal/ui/S3Component.groovy
+++ b/plugins/nexus-blobstore-s3/src/main/java/org/sonatype/nexus/blobstore/s3/internal/ui/S3Component.groovy
@@ -68,4 +68,19 @@ class S3Component
         new S3SignerTypeXO(order: 2, id: AmazonS3Client.S3_V4_SIGNER, name: AmazonS3Client.S3_V4_SIGNER)
     ]
   }
+
+  /**
+   * S3 force path style
+   */
+  @DirectMethod
+  @Timed
+  @ExceptionMetered
+  @RequiresPermissions('nexus:settings:read')
+  List<S3ForcePathStyleXO> forcepathstyles() {
+    [
+        new S3ForcePathStyleXO(order: 0, id: "false", name: "false"),
+        new S3ForcePathStyleXO(order: 1, id: "true", name: "true")
+    ]
+  }
+
 }

--- a/plugins/nexus-blobstore-s3/src/main/java/org/sonatype/nexus/blobstore/s3/internal/ui/S3ForcePathStyleXO.groovy
+++ b/plugins/nexus-blobstore-s3/src/main/java/org/sonatype/nexus/blobstore/s3/internal/ui/S3ForcePathStyleXO.groovy
@@ -1,0 +1,28 @@
+/*
+ * Sonatype Nexus (TM) Open Source Version
+ * Copyright (c) 2008-present Sonatype, Inc.
+ * All rights reserved. Includes the third-party code listed at http://links.sonatype.com/products/nexus/oss/attributions.
+ *
+ * This program and the accompanying materials are made available under the terms of the Eclipse Public License Version 1.0,
+ * which accompanies this distribution and is available at http://www.eclipse.org/legal/epl-v10.html.
+ *
+ * Sonatype Nexus (TM) Professional Version is available from Sonatype, Inc. "Sonatype" and "Sonatype Nexus" are trademarks
+ * of Sonatype, Inc. Apache Maven is a trademark of the Apache Software Foundation. M2eclipse is a trademark of the
+ * Eclipse Foundation. All other trademarks are the property of their respective owners.
+ */
+package org.sonatype.nexus.blobstore.s3.internal.ui
+
+import groovy.transform.ToString
+
+/**
+ * S3 force path style exchange object.
+ *
+ * @since 3.12
+ */
+@ToString(includePackage = false, includeNames = true)
+class S3ForcePathStyleXO
+{
+  int order
+  String id
+  String name
+}


### PR DESCRIPTION
This patch is allow to set [withPathStyleAccessEnabled](https://docs.aws.amazon.com/AWSJavaSDK/latest/javadoc/com/amazonaws/services/s3/AmazonS3Builder.html#withPathStyleAccessEnabled-java.lang.Boolean-) parameter of Amazon S3 client.
This is useful for fakeS3 storages.