### PR TITLE
Add path prefix configuration for bucket objects

### DIFF
--- a/components/nexus-common/src/test/java/org/sonatype/nexus/common/io/DirectoryHelperTest.java
+++ b/components/nexus-common/src/test/java/org/sonatype/nexus/common/io/DirectoryHelperTest.java
@@ -233,7 +233,7 @@ public class DirectoryHelperTest
    * and deeper. {@link FileSystemException} is thrown once file path length reaches OS limit. In case
    * of repo local storage, the root was being moved under "/.nexus/trash".
    */
-  @Test(expected = FileSystemException.class)
+  @Test(expected = IllegalArgumentException.class)
   public void moveToSubdir() throws IOException {
     final Path target = root.toPath().resolve("dir2/dir21");
     DirectoryHelper.move(root.toPath(), target);

--- a/plugins/nexus-blobstore-s3/src/main/java/org/sonatype/nexus/blobstore/s3/internal/S3BlobStore.java
+++ b/plugins/nexus-blobstore-s3/src/main/java/org/sonatype/nexus/blobstore/s3/internal/S3BlobStore.java
@@ -94,6 +94,8 @@ public class S3BlobStore
 
   public static final String BUCKET_KEY = "bucket";
 
+  public static final String BUCKET_PREFIX = "prefix";
+
   public static final String ACCESS_KEY_ID_KEY = "accessKeyId";
 
   public static final String SECRET_ACCESS_KEY_KEY = "secretAccessKey";
@@ -164,7 +166,7 @@ public class S3BlobStore
   @Override
   protected void doStart() throws Exception {
     // ensure blobstore is supported
-    S3PropertiesFile metadata = new S3PropertiesFile(s3, getConfiguredBucket(), METADATA_FILENAME);
+    S3PropertiesFile metadata = new S3PropertiesFile(s3, getConfiguredBucket(), metadataFilePath());
     if (metadata.exists()) {
       metadata.load();
       String type = metadata.getProperty(TYPE_KEY);
@@ -177,6 +179,7 @@ public class S3BlobStore
     }
     liveBlobs = CacheBuilder.newBuilder().weakValues().build(from(S3Blob::new));
     storeMetrics.setBucket(getConfiguredBucket());
+    storeMetrics.setBucketPrefix(getBucketPrefix());
     storeMetrics.setS3(s3);
     storeMetrics.start();
   }
@@ -194,6 +197,10 @@ public class S3BlobStore
     return getLocation(id) + BLOB_CONTENT_SUFFIX;
   }
 
+  private String metadataFilePath() {
+    return getBucketPrefix() + METADATA_FILENAME;
+  }
+
   /**
    * Returns path for blob-id attribute file relative to root directory.
    */
@@ -205,7 +212,7 @@ public class S3BlobStore
    * Returns the location for a blob ID based on whether or not the blob ID is for a temporary or permanent blob.
    */
   private String getLocation(final BlobId id) {
-    return CONTENT_PREFIX + "/" + blobIdLocationResolver.getLocation(id);
+    return getBucketPrefix() + CONTENT_PREFIX + "/" + blobIdLocationResolver.getLocation(id);
   }
 
   @Override
@@ -553,6 +560,14 @@ public class S3BlobStore
     );
   }
 
+  private String getBucketPrefix() {
+    return Optional.ofNullable(blobStoreConfiguration.attributes(CONFIG_KEY).get(BUCKET_PREFIX))
+                   .map(Object::toString)
+                   .filter(s -> !s.isEmpty())
+                   .map(s -> s.replaceFirst("/$", "") + "/")
+                   .orElse("");
+  }
+
   /**
    * Delete files known to be part of the S3BlobStore implementation if the content directory is empty.
    */
@@ -562,7 +577,7 @@ public class S3BlobStore
     try {
       boolean contentEmpty = s3.listObjects(getConfiguredBucket(), CONTENT_PREFIX + "/").getObjectSummaries().isEmpty();
       if (contentEmpty) {
-        S3PropertiesFile metadata = new S3PropertiesFile(s3, getConfiguredBucket(), METADATA_FILENAME);
+        S3PropertiesFile metadata = new S3PropertiesFile(s3, getConfiguredBucket(), metadataFilePath());
         metadata.remove();
         storeMetrics.remove();
         s3.deleteBucket(getConfiguredBucket());
@@ -610,7 +625,7 @@ public class S3BlobStore
 
   @Override
   public Stream<BlobId> getDirectPathBlobIdStream(final String prefix) {
-    String subpath = format("%s/%s", DIRECT_PATH_PREFIX, prefix);
+    String subpath = getBucketPrefix() + format("%s/%s", DIRECT_PATH_PREFIX, prefix);
     Iterable<S3ObjectSummary> summaries = S3Objects.withPrefix(s3, getConfiguredBucket(), subpath);
     return stream(summaries.spliterator(), false)
       .map(S3ObjectSummary::getKey)
@@ -719,11 +734,11 @@ public class S3BlobStore
    * @see BlobIdLocationResolver
    */
   private BlobId attributePathToDirectPathBlobId(final String s3Key) { // NOSONAR
-    checkArgument(s3Key.startsWith(DIRECT_PATH_PREFIX + "/"), "Not direct path blob path: %s", s3Key);
+    checkArgument(s3Key.startsWith(getBucketPrefix() + DIRECT_PATH_PREFIX + "/"), "Not direct path blob path: %s", s3Key);
     checkArgument(s3Key.endsWith(BLOB_ATTRIBUTE_SUFFIX), "Not blob attribute path: %s", s3Key);
     String blobName = s3Key
         .substring(0, s3Key.length() - BLOB_ATTRIBUTE_SUFFIX.length())
-        .substring(DIRECT_PATH_PREFIX.length() + 1);
+        .substring((getBucketPrefix() + DIRECT_PATH_PREFIX).length() + 1);
     Map<String, String> headers = ImmutableMap.of(
         BLOB_NAME_HEADER, blobName,
         DIRECT_PATH_BLOB_HEADER, "true"

--- a/plugins/nexus-blobstore-s3/src/main/java/org/sonatype/nexus/blobstore/s3/internal/S3BlobStoreDescriptor.java
+++ b/plugins/nexus-blobstore-s3/src/main/java/org/sonatype/nexus/blobstore/s3/internal/S3BlobStoreDescriptor.java
@@ -49,6 +49,12 @@ public class S3BlobStoreDescriptor
     @DefaultMessage("S3 Bucket Name (must be between 3 and 63 characters long containing only lower-case characters, numbers, periods, and dashes)")
     String bucketHelp();
 
+    @DefaultMessage("Prefix")
+    String prefixLabel();
+
+    @DefaultMessage("S3 Path prefix")
+    String prefixHelp();
+
     @DefaultMessage("Access Key ID (Optional)")
     String accessKeyIdLabel();
 
@@ -101,6 +107,7 @@ public class S3BlobStoreDescriptor
   private static final Messages messages = I18N.create(Messages.class);
 
   private final FormField bucket;
+  private final FormField prefix;
   private final FormField accessKeyId;
   private final FormField secretAccessKey;
   private final FormField sessionToken;
@@ -117,6 +124,12 @@ public class S3BlobStoreDescriptor
         messages.bucketHelp(),
         FormField.MANDATORY,
         S3BlobStore.BUCKET_REGEX
+    );
+    this.prefix = new StringTextFormField(
+        S3BlobStore.BUCKET_PREFIX,
+        messages.prefixLabel(),
+        messages.prefixHelp(),
+        FormField.OPTIONAL
     );
     this.accessKeyId = new StringTextFormField(
         S3BlobStore.ACCESS_KEY_ID_KEY,
@@ -180,7 +193,7 @@ public class S3BlobStoreDescriptor
 
   @Override
   public List<FormField> getFormFields() {
-    return Arrays.asList(bucket, accessKeyId, secretAccessKey, sessionToken, assumeRole, region, endpoint,
+    return Arrays.asList(bucket, prefix, accessKeyId, secretAccessKey, sessionToken, assumeRole, region, endpoint,
         expiration, signerType);
   }
 }

--- a/plugins/nexus-blobstore-s3/src/main/java/org/sonatype/nexus/blobstore/s3/internal/S3BlobStoreMetricsStore.java
+++ b/plugins/nexus-blobstore-s3/src/main/java/org/sonatype/nexus/blobstore/s3/internal/S3BlobStoreMetricsStore.java
@@ -71,6 +71,8 @@ public class S3BlobStoreMetricsStore
 
   private String bucket;
 
+  private String bucketPrefix;
+
   private S3PropertiesFile propertiesFile;
 
   private AmazonS3 s3;
@@ -87,7 +89,7 @@ public class S3BlobStoreMetricsStore
     totalSize = new AtomicLong();
     dirty = new AtomicBoolean();
 
-    propertiesFile = new S3PropertiesFile(s3, bucket, nodeAccess.getId() + METRICS_SUFFIX + METRICS_EXTENSION);
+    propertiesFile = new S3PropertiesFile(s3, bucket, bucketPrefix + nodeAccess.getId() + METRICS_SUFFIX + METRICS_EXTENSION);
     if (propertiesFile.exists()) {
       log.info("Loading blob store metrics file {}", propertiesFile);
       propertiesFile.load();
@@ -138,6 +140,13 @@ public class S3BlobStoreMetricsStore
     checkState(this.s3 == null, "Do not initialize twice");
     checkNotNull(s3);
     this.s3 = s3;
+  }
+
+
+  public void setBucketPrefix(String bucketPrefix) {
+    checkState(this.bucketPrefix == null, "Do not initialize twice");
+    checkNotNull(bucketPrefix);
+    this.bucketPrefix = bucketPrefix;
   }
 
   @Guarded(by = STARTED)
@@ -192,7 +201,7 @@ public class S3BlobStoreMetricsStore
     if (s3 == null) {
       return Stream.empty();
     } else {
-      Stream<S3PropertiesFile> stream = s3.listObjects(bucket, nodeAccess.getId()).getObjectSummaries().stream()
+      Stream<S3PropertiesFile> stream = s3.listObjects(bucket, bucketPrefix + nodeAccess.getId()).getObjectSummaries().stream()
           .filter(summary -> summary.getKey().endsWith(METRICS_EXTENSION))
           .map(summary -> new S3PropertiesFile(s3, bucket, summary.getKey()));
       return stream;

--- a/plugins/nexus-blobstore-s3/src/test/java/org/sonatype/nexus/blobstore/s3/internal/S3BlobStoreTest.groovy
+++ b/plugins/nexus-blobstore-s3/src/test/java/org/sonatype/nexus/blobstore/s3/internal/S3BlobStoreTest.groovy
@@ -77,26 +77,36 @@ class S3BlobStoreTest
     config.attributes = [s3: [bucket: 'mybucket']]
   }
 
-  def "Get blob"() {
+  def "Get blob"(String prefix) {
     given: 'A mocked S3 setup'
+      def cfg = new BlobStoreConfiguration()
+      cfg.attributes = [s3: [bucket: 'mybucket', prefix: prefix]]
+      def pathPrefix = prefix ? (prefix + "/") : ""
+
       def blobId = new BlobId('test')
       def attributesS3Object = mockS3Object(attributesContents)
       def contentS3Object = mockS3Object('hello world')
       1 * s3.doesBucketExist('mybucket') >> true
       1 * s3.getBucketLifecycleConfiguration('mybucket') >>
           blobStore.makeLifecycleConfiguration(null, S3BlobStore.DEFAULT_EXPIRATION_IN_DAYS)
-      1 * s3.doesObjectExist('mybucket', 'metadata.properties') >> false
-      1 * s3.doesObjectExist('mybucket', propertiesLocation(blobId)) >> true
-      1 * s3.getObject('mybucket', propertiesLocation(blobId)) >> attributesS3Object
-      1 * s3.getObject('mybucket', bytesLocation(blobId)) >> contentS3Object
+      1 * s3.doesObjectExist('mybucket', pathPrefix + 'metadata.properties') >> false
+      1 * s3.doesObjectExist('mybucket', pathPrefix + propertiesLocation(blobId)) >> true
+      1 * s3.getObject('mybucket', pathPrefix + propertiesLocation(blobId)) >> attributesS3Object
+      1 * s3.getObject('mybucket', pathPrefix + bytesLocation(blobId)) >> contentS3Object
 
     when: 'An existing blob is read'
-      blobStore.init(config)
+      blobStore.init(cfg)
       blobStore.doStart()
       def blob = blobStore.get(blobId)
 
     then: 'The contents are read from s3'
       blob.inputStream.text == 'hello world'
+
+    where:
+      prefix   | _
+    //null     | _
+      ""       | _
+      "prefix" | _
   }
 
   def 'set lifecycle on pre-existing bucket if not present'() {
@@ -110,14 +120,18 @@ class S3BlobStoreTest
       1 * s3.setBucketLifecycleConfiguration('mybucket', !null)
   }
 
-  def 'soft delete successful'() {
+  def 'soft delete successful'(String prefix) {
     given: 'blob exists'
       def blobId = new BlobId('soft-delete-success')
-      blobStore.init(config)
+      def cfg = new BlobStoreConfiguration()
+      cfg.attributes = [s3: [bucket: 'mybucket', prefix: prefix]]
+      def pathPrefix = prefix ? (prefix + "/") : ""
+
+      blobStore.init(cfg)
       blobStore.doStart()
       def attributesS3Object = mockS3Object(attributesContents)
-      1 * s3.doesObjectExist('mybucket', propertiesLocation(blobId)) >> true
-      1 * s3.getObject('mybucket', propertiesLocation(blobId)) >> attributesS3Object
+      1 * s3.doesObjectExist('mybucket', pathPrefix + propertiesLocation(blobId)) >> true
+      1 * s3.getObject('mybucket', pathPrefix + propertiesLocation(blobId)) >> attributesS3Object
 
     when: 'blob is deleted'
       def deleted = blobStore.delete(blobId, 'successful test')
@@ -132,6 +146,12 @@ class S3BlobStoreTest
         assert args[0].getKey().endsWith(BLOB_ATTRIBUTE_SUFFIX) == true
         assert args[0].getTagging().getTagSet() == [S3BlobStore.DELETED_TAG]
       }
+
+    where:
+      prefix   | _
+      null     | _
+      ""       | _
+      "prefix" | _
   }
 
   def 'soft delete returns false when blob does not exist'() {


### PR DESCRIPTION
This change enables users to configure a path prefix for objects stored in the
S3 bucket, effectively allowing multiple blob stores / repositories to share
the same bucket. This can simplify bucket management significantly in cases
where DevOps requires more control over buckets.