### PR TITLE
Implements exclusive rules for Nexus 3

### DIFF
--- a/components/nexus-repository/src/main/java/org/sonatype/nexus/repository/security/SecurityHandler.java
+++ b/components/nexus-repository/src/main/java/org/sonatype/nexus/repository/security/SecurityHandler.java
@@ -37,6 +37,8 @@ public class SecurityHandler
   @VisibleForTesting
   static final String AUTHORIZED_KEY = "security.authorized";
 
+  private final boolean AUTHORIZE_ALWAYS = true;
+
   @Nonnull
   @Override
   public Response handle(@Nonnull final Context context) throws Exception {
@@ -44,7 +46,10 @@ public class SecurityHandler
 
     //we employ the model that one security check per request is all that is necessary, if this handler is in a nested
     //repository (because this is a group repository), there is no need to check authz again
-    if (context.getAttributes().get(AUTHORIZED_KEY) == null) {
+
+    //Optional: Implements exclusive rules by auth validation for all nested repositories
+
+    if (AUTHORIZE_ALWAYS || context.getAttributes().get(AUTHORIZED_KEY) == null) {
       securityFacet.ensurePermitted(context.getRequest());
       context.getAttributes().set(AUTHORIZED_KEY, true);
     }


### PR DESCRIPTION
Implements exclusive rules by auth validation for all nested repositories (currently, authorization is only for a group).
Need for access to hosted artifact without access to same artifact from proxy repository.
Realised by privilege with negative regexp content selector for nested proxy repository.