### PR TITLE
nexus-blobstore-s3: Adds an option to allow forcing path-style access

### DIFF
--- a/plugins/nexus-blobstore-s3/src/main/java/org/sonatype/nexus/blobstore/s3/internal/AmazonS3Factory.java
+++ b/plugins/nexus-blobstore-s3/src/main/java/org/sonatype/nexus/blobstore/s3/internal/AmazonS3Factory.java
@@ -42,6 +42,7 @@ import static org.sonatype.nexus.blobstore.s3.internal.S3BlobStore.REGION_KEY;
 import static org.sonatype.nexus.blobstore.s3.internal.S3BlobStore.SECRET_ACCESS_KEY_KEY;
 import static org.sonatype.nexus.blobstore.s3.internal.S3BlobStore.SESSION_TOKEN_KEY;
 import static org.sonatype.nexus.blobstore.s3.internal.S3BlobStore.SIGNERTYPE_KEY;
+import static org.sonatype.nexus.blobstore.s3.internal.S3BlobStore.FORCE_PATH_STYLE_KEY;
 
 /**
  * Creates configured AmazonS3 clients.
@@ -61,6 +62,7 @@ public class AmazonS3Factory
     String secretAccessKey = blobStoreConfiguration.attributes(CONFIG_KEY).get(SECRET_ACCESS_KEY_KEY, String.class);
     String region = blobStoreConfiguration.attributes(CONFIG_KEY).get(REGION_KEY, String.class);
     String signerType = blobStoreConfiguration.attributes(CONFIG_KEY).get(SIGNERTYPE_KEY, String.class);
+    String forcePathStyle = blobStoreConfiguration.attributes(CONFIG_KEY).get(FORCE_PATH_STYLE_KEY, String.class);
 
     if (!isNullOrEmpty(accessKeyId) && !isNullOrEmpty(secretAccessKey)) {
       String sessionToken = blobStoreConfiguration.attributes(CONFIG_KEY).get(SESSION_TOKEN_KEY, String.class);
@@ -85,6 +87,10 @@ public class AmazonS3Factory
       ClientConfiguration clientConfiguration = PredefinedClientConfigurations.defaultConfig();
       clientConfiguration.setSignerOverride(signerType);
       builder = builder.withClientConfiguration(clientConfiguration);
+    }
+
+    if (!isNullOrEmpty(forcePathStyle) && forcePathStyle.equalsIgnoreCase("true")) {
+      builder.enablePathStyleAccess();
     }
 
     return builder.build();

--- a/plugins/nexus-blobstore-s3/src/main/java/org/sonatype/nexus/blobstore/s3/internal/S3BlobStore.java
+++ b/plugins/nexus-blobstore-s3/src/main/java/org/sonatype/nexus/blobstore/s3/internal/S3BlobStore.java
@@ -111,6 +111,8 @@ public class S3BlobStore
 
   public static final String SIGNERTYPE_KEY = "signertype";
 
+  public static final String FORCE_PATH_STYLE_KEY = "forcepathstyle";
+
   public static final String BUCKET_REGEX =
       "^([a-z]|(\\d(?!\\d{0,2}\\.\\d{1,3}\\.\\d{1,3}\\.\\d{1,3})))([a-z\\d]|(\\.(?!(\\.|-)))|(-(?!\\.))){1,61}[a-z\\d]$";
 

--- a/plugins/nexus-blobstore-s3/src/main/java/org/sonatype/nexus/blobstore/s3/internal/S3BlobStoreDescriptor.java
+++ b/plugins/nexus-blobstore-s3/src/main/java/org/sonatype/nexus/blobstore/s3/internal/S3BlobStoreDescriptor.java
@@ -20,6 +20,7 @@ import javax.inject.Named;
 import org.sonatype.goodies.i18n.I18N;
 import org.sonatype.goodies.i18n.MessageBundle;
 import org.sonatype.nexus.blobstore.BlobStoreDescriptor;
+import org.sonatype.nexus.formfields.CheckboxFormField;
 import org.sonatype.nexus.formfields.ComboboxFormField;
 import org.sonatype.nexus.formfields.FormField;
 import org.sonatype.nexus.formfields.NumberTextFormField;
@@ -96,6 +97,12 @@ public class S3BlobStoreDescriptor
 
     @DefaultMessage("An API signature version which may be required for third party object stores using the S3 API")
     String signerTypeHelp();
+
+    @DefaultMessage("Configures the client to use path-style access")
+    String forcePathStyleLabel();
+
+    @DefaultMessage("Setting this flag will result in path-style access being used for all requests")
+    String forcePathStyleHelp();
   }
 
   private static final Messages messages = I18N.create(Messages.class);
@@ -109,6 +116,7 @@ public class S3BlobStoreDescriptor
   private final FormField endpoint;
   private final FormField expiration;
   private final FormField signerType;
+  private final FormField forcePathStyle;
 
   public S3BlobStoreDescriptor() {
     this.bucket = new StringTextFormField(
@@ -171,6 +179,12 @@ public class S3BlobStoreDescriptor
         AmazonS3Factory.DEFAULT
     ).withStoreApi("s3_S3.signertypes");
     this.signerType.getAttributes().put("sortProperty", "order");
+    this.forcePathStyle = new CheckboxFormField(
+        S3BlobStore.FORCE_PATH_STYLE_KEY,
+        messages.forcePathStyleLabel(),
+        messages.forcePathStyleHelp(),
+        FormField.OPTIONAL
+    );
   }
 
   @Override
@@ -181,6 +195,6 @@ public class S3BlobStoreDescriptor
   @Override
   public List<FormField> getFormFields() {
     return Arrays.asList(bucket, accessKeyId, secretAccessKey, sessionToken, assumeRole, region, endpoint,
-        expiration, signerType);
+        expiration, signerType, forcePathStyle);
   }
 }


### PR DESCRIPTION
This is effectively the same as PR #35 but instead uses a `CheckboxFormField` as was requested.

Having this option increases compatibility with third-party S3 storage services.