### PR TITLE
Fix test failures on Windows

### DIFF
--- a/components/nexus-core/src/test/java/org/sonatype/nexus/internal/atlas/SystemInformationGeneratorImplTest.groovy
+++ b/components/nexus-core/src/test/java/org/sonatype/nexus/internal/atlas/SystemInformationGeneratorImplTest.groovy
@@ -75,9 +75,22 @@ class SystemInformationGeneratorImplTest
   def "reportNetwork runs successfully using NetworkInterface.networkInterfaces"() {
     given:
       def generator = mockSystemInformationGenerator()
+      def intf = GroovyMock(NetworkInterface) {
+        getName() >> "lo"
+        getDisplayName() >> "Software Loopback Interface 1"
+        isUp() >> true
+        isVirtual() >> false
+        supportsMulticast() >> true
+        isLoopback() >> true
+        isPointToPoint() >> false
+        getMTU() >> -1
+        getInetAddresses() >> {
+          return Collections.enumeration(Collections.singletonList(InetAddress.localHost))
+        }
+      }
 
     when:
-      def data = NetworkInterface.networkInterfaces.toList().collectEntries {
+      def data = Collections.singletonList(intf).collectEntries {
         [ (it.name): generator.reportNetworkInterface(it) ]
       }
 

--- a/plugins/nexus-coreui-plugin/src/test/java/org/sonatype/nexus/coreui/BlobStoreComponentTest.groovy
+++ b/plugins/nexus-coreui-plugin/src/test/java/org/sonatype/nexus/coreui/BlobStoreComponentTest.groovy
@@ -12,6 +12,8 @@
  */
 package org.sonatype.nexus.coreui
 
+import java.nio.file.Paths
+
 import org.sonatype.nexus.blobstore.BlobStoreDescriptor
 import org.sonatype.nexus.blobstore.api.BlobStore
 import org.sonatype.nexus.blobstore.api.BlobStoreConfiguration
@@ -100,7 +102,7 @@ class BlobStoreComponentTest
 
   def 'Default work directory returns the blobs directory'() {
     given: 'A blob directory'
-      def blobDirectory = 'path/to/blobs'
+      def blobDirectory = Paths.get('path', 'to', 'blobs').toString()
 
     when: 'The blob directory is requested'
       def defaultWorkDirectory = blobStoreComponent.defaultWorkDirectory()


### PR DESCRIPTION
nexus-core and coreui each have a test that consistently fails on Windows.  For coreui, it was a hard-coded use of UNIX-style path separators.  For nexus-core, it was exercising the code against the host system's network interfaces rather than a mock that provides the correct configuration for the test.