### PR TITLE
NEXUS-18510: Repository: Add explicit mime-type override for Apache Nifi Archive (NAR) files.

### DIFF
--- a/components/nexus-mime/src/main/resources/builtin-mimetypes.properties
+++ b/components/nexus-mime/src/main/resources/builtin-mimetypes.properties
@@ -31,5 +31,6 @@ bz2 = application/x-bzip2
 tbz = application/x-bzip2,application/x-bzip
 nupkg = application/zip
 kar = application/zip
+nar = application/zip
 woff = application/font-woff,application/x-font-woff
 exe = application/x-executable,application/x-dosexec,application/x-msdownload


### PR DESCRIPTION
Adds an explicit `nar = application/zip` entry in `nexus-mime/src/main/resources/builtin-mimetypes.properties` in order to allow the uploading of Apache Nifi Archive (NAR) files. Without this override, these files are detected by Tika as `application/vnd.iptc.g2.newsmessage+xml` when strict content validation is turned on for a given repository.

This is likely a result of upgrading Tika to version `1.19` as part of commit 1ad19d8 ; according to Tika, they added support for detecting  `application/vnd.iptc.g2.newsmessage+xml` in Tika `1.18` (ref. Jira TIKA-2527) which results in NAR uploads not working in the aforementioned scenario in Nexus `3.14.0`.