### PR TITLE
Removed new line char "\n" from "version"

### DIFF
--- a/plugins/nexus-repository-cocoapods/src/main/java/org/sonatype/nexus/repository/cocoapods/internal/proxy/SpecTransformer.java
+++ b/plugins/nexus-repository-cocoapods/src/main/java/org/sonatype/nexus/repository/cocoapods/internal/proxy/SpecTransformer.java
@@ -82,7 +82,7 @@ public class SpecTransformer
     }
 
     final String name = jsonSpec.get(POD_NAME_FIELD).asText();
-    final String version = jsonSpec.get(POD_VERSION_FIELD).asText();
+    final String version = jsonSpec.get(POD_VERSION_FIELD).asText().trim();
 
     URI sourceUri = buidProxiedUri(jsonSpec.get(SOURCE_NODE_NAME), name, version, repoUri);
 


### PR DESCRIPTION
New line char causes an error over NXRM. Removed new line "\n" from version.

**Pod Error Message:**

> [!] CDN: xxxxx-repository-cocoapods-proxy Repo update failed - 7 error(s):
> CDN: xxxxx-repository-cocoapods-proxy URL couldn't be downloaded: https://xxxxx/repository/cocoapods-proxy/Specs/9/4/5/RealmSwift/0.92.1/RealmSwift.podspec.json Response: 500
> CDN: xxxxx-repository-cocoapods-proxy URL couldn't be downloaded: https://xxxxx/repository/cocoapods-proxy/Specs/9/4/5/RealmSwift/0.92.2/RealmSwift.podspec.json Response: 500
> CDN: xxxxx-repository-cocoapods-proxy URL couldn't be downloaded: https://xxxxx/repository/cocoapods-proxy/Specs/9/4/5/RealmSwift/0.92.3/RealmSwift.podspec.json Response: 500
> CDN: xxxxx-repository-cocoapods-proxy URL couldn't be downloaded: https://xxxxx/repository/cocoapods-proxy/Specs/9/4/5/RealmSwift/0.92.4/RealmSwift.podspec.json Response: 500
> CDN: xxxxx-repository-cocoapods-proxy URL couldn't be downloaded: https://xxxxx/repository/cocoapods-proxy/Specs/9/4/5/RealmSwift/0.93.0/RealmSwift.podspec.json Response: 500
> CDN: xxxxx-repository-cocoapods-proxy URL couldn't be downloaded: https://xxxxx/repository/cocoapods-proxy/Specs/9/4/5/RealmSwift/0.93.1/RealmSwift.podspec.json Response: 500
> CDN: xxxxx-repository-cocoapods-proxy URL couldn't be downloaded: https://xxxxx/repository/cocoapods-proxy/Specs/9/4/5/RealmSwift/0.93.2/RealmSwift.podspec.json Response: 500

**Nexus Error Message:**

> javax.servlet.ServletException: java.lang.IllegalArgumentException: Illegal character in path at index 22: pods/RealmSwift/0.92.1
> /https/api.github.com/repos/realm/realm-cocoa/tarball/v0.92.1.tar.gz

**RealmSwift.podspec.json**
```
{
  "name": "RealmSwift",
  "version": "0.92.1\n",
  "summary": "Realm is a modern data framework & database for iOS & OS X.",
  ...
}
```