### PR TITLE
Do not try to delete a non-existing lifecycleconfiguration NEXUS-17645

### DIFF
--- a/plugins/nexus-blobstore-s3/src/main/java/org/sonatype/nexus/blobstore/s3/internal/BucketManager.java
+++ b/plugins/nexus-blobstore-s3/src/main/java/org/sonatype/nexus/blobstore/s3/internal/BucketManager.java
@@ -185,7 +185,10 @@ public class BucketManager
       s3.setBucketLifecycleConfiguration(bucket, newLifecycleConfiguration);
     }
     else {
-      s3.deleteBucketLifecycleConfiguration(bucket);
+      // check if there is a lifecycleconfiguration before trying to delete one
+      if (s3.getBucketLifecycleConfiguration(bucket) != null) {
+        s3.deleteBucketLifecycleConfiguration(bucket);
+      }
     }
   }
 

--- a/plugins/nexus-blobstore-s3/src/test/java/org/sonatype/nexus/blobstore/s3/internal/BucketManagerTest.groovy
+++ b/plugins/nexus-blobstore-s3/src/test/java/org/sonatype/nexus/blobstore/s3/internal/BucketManagerTest.groovy
@@ -178,6 +178,24 @@ class BucketManagerTest
       0 * s3.setBucketLifecycleConfiguration(_, _)
   }
 
+  def 'lifecycle configuration does not try to deleted non-existing one'() {
+    given: 'bucket without lifecycle configuration'
+
+    s3.doesBucketExistV2('mybucket') >> true
+    s3.getBucketLifecycleConfiguration('mybucket') >> null
+
+    def cfg = new BlobStoreConfiguration(name: 'mybucket')
+    cfg.attributes = [s3: [bucket: 'mybucket', expiration: '0']]
+    bucketManager.s3 = s3
+
+    when: 'prepareStorageLocation called'
+    bucketManager.prepareStorageLocation(cfg)
+
+    then: 'no call to delete non-existent lifecycle configuration'
+    0 * s3.deleteBucketLifecycleConfiguration(_)
+    0 * s3.setBucketLifecycleConfiguration(_, _)
+  }
+
   def 'global lifecycle rule switched to blob store specific if present'() {
     given: 'global lifecycleConfiguration with inital expiry days'
       def bucketConfig = new BucketLifecycleConfiguration()


### PR DESCRIPTION
This change is related to [NEXUS-17645.](https://issues.sonatype.org/browse/NEXUS-17645)

Even when you try to create a S3 storage - backed by minio - saying "Expiration Days" disabled

> How many days until deleted blobs are finally removed from the S3 bucket (-1 to disable)

the creation of the blob stores still fails, because it tries to delete the bucket lifecycle configuration also there is none.

This would make it possible again to use minio as s3 blob storage (in combination with https://github.com/sonatype/nexus-public/pull/55)