### PR TITLE
Replace CRLF with LF on release files

### DIFF
--- a/plugins/nexus-repository-apt/src/main/java/org/sonatype/nexus/repository/apt/internal/hosted/AptHostedFacet.java
+++ b/plugins/nexus-repository-apt/src/main/java/org/sonatype/nexus/repository/apt/internal/hosted/AptHostedFacet.java
@@ -172,11 +172,14 @@ public class AptHostedFacet
       releaseFile = buildReleaseFile(aptFacet.getDistribution(), store.getFiles().keySet(), md5Builder.toString(),
           sha256Builder.toString());
     }
+    releaseFile = releaseFile.replace("\r", "");
 
     aptFacet.put(releaseIndexName(RELEASE), new BytesPayload(releaseFile.getBytes(Charsets.UTF_8), AptMimeTypes.TEXT));
     byte[] inRelease = signingFacet.signInline(releaseFile);
+    inRelease = new String(inRelease, Charsets.UTF_8).replace("\r", "").getBytes();
     aptFacet.put(releaseIndexName(INRELEASE), new BytesPayload(inRelease, AptMimeTypes.TEXT));
     byte[] releaseGpg = signingFacet.signExternal(releaseFile);
+    releaseGpg = new String(releaseGpg, Charsets.UTF_8).replace("\r", "").getBytes();
     aptFacet.put(releaseIndexName(RELEASE_GPG), new BytesPayload(releaseGpg, AptMimeTypes.SIGNATURE));
   }
 


### PR DESCRIPTION
This resolves [NEXUS-21834](https://issues.sonatype.org/browse/NEXUS-21834) which prevents APT repositories from working when running under Windows