### PR TITLE
Add swagger response models

### DIFF
--- a/components/nexus-core/src/main/java/org/sonatype/nexus/internal/email/rest/EmailConfigurationApiResourceDoc.java
+++ b/components/nexus-core/src/main/java/org/sonatype/nexus/internal/email/rest/EmailConfigurationApiResourceDoc.java
@@ -50,7 +50,7 @@ public interface EmailConfigurationApiResourceDoc
 
   @ApiOperation("Send a test email to the email address provided in the request body")
   @ApiResponses(value = {
-      @ApiResponse(code = OK, message = "Validation was complete, look at the body to determine success"),
+      @ApiResponse(code = OK, message = "Validation was complete, look at the body to determine success", response = ApiEmailValidation.class),
       @ApiResponse(code = FORBIDDEN, message = "Insufficient permissions to verify the email configuration")
   })
   ApiEmailValidation testEmailConfiguration(

--- a/components/nexus-core/src/main/java/org/sonatype/nexus/internal/status/StatusResourceDoc.java
+++ b/components/nexus-core/src/main/java/org/sonatype/nexus/internal/status/StatusResourceDoc.java
@@ -61,7 +61,7 @@ public interface StatusResourceDoc
   @GET
   @ApiOperation("Health check endpoint that returns the results of the system status checks")
   @ApiResponses({
-      @ApiResponse(code = 200, message = "The system status check results")
+      @ApiResponse(code = 200, message = "The system status check results", response = Result.class, responseContainer = "Map")
   })
   SortedMap<String, Result> getSystemStatusChecks();
 

--- a/components/nexus-repository/src/main/java/org/sonatype/nexus/repository/rest/api/RepositoriesApiResourceDoc.java
+++ b/components/nexus-repository/src/main/java/org/sonatype/nexus/repository/rest/api/RepositoriesApiResourceDoc.java
@@ -47,7 +47,7 @@ public interface RepositoriesApiResourceDoc
       throws Exception;
 
   @ApiOperation("List repositories")
-  @ApiResponses(value = {@ApiResponse(code = 200, message = "Repositories list returned"),
+  @ApiResponses(value = {@ApiResponse(code = 200, message = "Repositories list returned", response = AbstractApiRepository.class, responseContainer = "List"),
       @ApiResponse(code = 401, message = AUTHENTICATION_REQUIRED),
       @ApiResponse(code = 403, message = INSUFFICIENT_PERMISSIONS)})
   List<AbstractApiRepository> getRepositories();

--- a/components/nexus-repository/src/main/java/org/sonatype/nexus/repository/rest/internal/resources/doc/ContentSelectorsResourceDoc.java
+++ b/components/nexus-repository/src/main/java/org/sonatype/nexus/repository/rest/internal/resources/doc/ContentSelectorsResourceDoc.java
@@ -57,7 +57,7 @@ public interface ContentSelectorsResourceDoc
 
   @ApiOperation("List Content Selectors")
   @ApiResponses({
-      @ApiResponse(code = OK, message = "successful operation"),
+      @ApiResponse(code = OK, message = "successful operation", response = ContentSelectorApiResponse.class, responseContainer = "List"),
       @ApiResponse(code = FORBIDDEN, message = "Insufficient permissions to read content selectors")
   })
   List<ContentSelectorApiResponse> getContentSelectors();
@@ -72,7 +72,7 @@ public interface ContentSelectorsResourceDoc
 
   @ApiOperation("Get a content selector by id")
   @ApiResponses({
-      @ApiResponse(code = OK, message = "successful operation"),
+      @ApiResponse(code = OK, message = "successful operation", response = ContentSelectorApiResponse.class),
       @ApiResponse(code = FORBIDDEN, message = "Insufficient permissions to read the content selector")
   })
   ContentSelectorApiResponse getContentSelector(

--- a/plugins/nexus-ssl-plugin/src/main/java/com/sonatype/nexus/ssl/plugin/internal/rest/CertificateApiResourceDoc.java
+++ b/plugins/nexus-ssl-plugin/src/main/java/com/sonatype/nexus/ssl/plugin/internal/rest/CertificateApiResourceDoc.java
@@ -55,8 +55,7 @@ public interface CertificateApiResourceDoc
 
   @ApiOperation("Add a certificate to the trust store.")
   @ApiResponses(value = {
-      @ApiResponse(code = SC_CREATED, message = "The certificate was successfully added.",
-          reference = "com.sonatype.nexus.ssl.plugin.internal.rest.ApiCertificate"),
+      @ApiResponse(code = SC_CREATED, message = "The certificate was successfully added.", response = ApiCertificate.class),
       @ApiResponse(code = SC_CONFLICT,
           message = "The certificate already exists in the system."),
       @ApiResponse(code = SC_FORBIDDEN, message = "Insufficient permissions to add certificate to the trust store.")})


### PR DESCRIPTION
For REST endpoints where the documentation was overridden for HTTP 200 responses, the response Models are missing. This response data is useful for API client generation such as [go-swagger](https://github.com/go-swagger/go-swagger).

This PR adds the response types back.