### PR TITLE
Add REST endpoint for get repository

### DIFF
--- a/components/nexus-repository/src/main/java/org/sonatype/nexus/repository/rest/api/AuthorizingRepositoryManager.java
+++ b/components/nexus-repository/src/main/java/org/sonatype/nexus/repository/rest/api/AuthorizingRepositoryManager.java
@@ -144,7 +144,7 @@ public class AuthorizingRepositoryManager
     }
   }
 
-  private Repository getEditableRepositoryOrThrow(@Nonnull final String name)
+  public Repository getEditableRepositoryOrThrow(@Nonnull final String name)
       throws RepositoryNotFoundException
   {
     Repository repository = repositoryManager.get(name);

--- a/components/nexus-repository/src/main/java/org/sonatype/nexus/repository/rest/api/AuthorizingRepositoryManager.java
+++ b/components/nexus-repository/src/main/java/org/sonatype/nexus/repository/rest/api/AuthorizingRepositoryManager.java
@@ -12,6 +12,7 @@
  */
 package org.sonatype.nexus.repository.rest.api;
 
+import java.util.Collections;
 import java.util.List;
 
 import javax.annotation.Nonnull;
@@ -91,6 +92,20 @@ public class AuthorizingRepositoryManager
   }
 
   /**
+   * Returns a specific repository which the user has an administrative read privilege to.
+   */
+  public Repository getRepository(@Nonnull final String name)
+          throws RepositoryNotFoundException
+  {
+    Repository repository = repositoryManager.get(name);
+    if (repository == null) {
+      throw new RepositoryNotFoundException();
+    }
+    repositoryPermissionChecker.userHasRepositoryAdminPermission(Collections.singletonList(repository), READ);
+    return repository;
+  }
+
+  /**
    * Returns the repositories which the user has an administrative read privilege.
    */
   public List<Repository> getRepositoriesWithAdmin() {
@@ -144,7 +159,7 @@ public class AuthorizingRepositoryManager
     }
   }
 
-  public Repository getEditableRepositoryOrThrow(@Nonnull final String name)
+  private Repository getEditableRepositoryOrThrow(@Nonnull final String name)
       throws RepositoryNotFoundException
   {
     Repository repository = repositoryManager.get(name);

--- a/components/nexus-repository/src/main/java/org/sonatype/nexus/repository/rest/api/RepositoriesApiResource.java
+++ b/components/nexus-repository/src/main/java/org/sonatype/nexus/repository/rest/api/RepositoriesApiResource.java
@@ -89,7 +89,7 @@ public class RepositoriesApiResource
   @RequiresAuthentication
   public AbstractApiRepository getRepository(@PathParam("repositoryName") final String repositoryName) {
     try {
-      return convert(authorizingRepositoryManager.getEditableRepositoryOrThrow(repositoryName));
+      return convert(authorizingRepositoryManager.getRepository(repositoryName));
     } catch (RepositoryNotFoundException e) {
       log.debug("Repository not found '{}'", repositoryName, e);
       throw new WebApplicationMessageException(NOT_FOUND, "\"" + e.getMessage() + "\"", APPLICATION_JSON);

--- a/components/nexus-repository/src/main/java/org/sonatype/nexus/repository/rest/api/RepositoriesApiResource.java
+++ b/components/nexus-repository/src/main/java/org/sonatype/nexus/repository/rest/api/RepositoriesApiResource.java
@@ -84,6 +84,19 @@ public class RepositoriesApiResource
   }
 
   @Override
+  @GET
+  @Path("/{repositoryName}")
+  @RequiresAuthentication
+  public AbstractApiRepository getRepository(@PathParam("repositoryName") final String repositoryName) {
+    try {
+      return convert(authorizingRepositoryManager.getEditableRepositoryOrThrow(repositoryName));
+    } catch (RepositoryNotFoundException e) {
+      log.debug("Repository not found '{}'", repositoryName, e);
+      throw new WebApplicationMessageException(NOT_FOUND, "\"" + e.getMessage() + "\"", APPLICATION_JSON);
+    }
+  }
+
+  @Override
   @RequiresAuthentication
   @GET
   public List<AbstractApiRepository> getRepositories() {

--- a/components/nexus-repository/src/main/java/org/sonatype/nexus/repository/rest/api/RepositoriesApiResourceDoc.java
+++ b/components/nexus-repository/src/main/java/org/sonatype/nexus/repository/rest/api/RepositoriesApiResourceDoc.java
@@ -46,6 +46,13 @@ public interface RepositoriesApiResourceDoc
   Response deleteRepository(@ApiParam(value = "Name of the repository to delete") final String repositoryName)
       throws Exception;
 
+  @ApiOperation("Get repository")
+  @ApiResponses(value = {@ApiResponse(code = 200, message = "Repository returned", response = AbstractApiRepository.class),
+          @ApiResponse(code = 401, message = AUTHENTICATION_REQUIRED),
+          @ApiResponse(code = 403, message = INSUFFICIENT_PERMISSIONS),
+          @ApiResponse(code = 404, message = REPOSITORY_NOT_FOUND)})
+  AbstractApiRepository getRepository(@ApiParam(value = "Name of the repository to fetch") final String repositoryName) throws RepositoryNotFoundException;
+
   @ApiOperation("List repositories")
   @ApiResponses(value = {@ApiResponse(code = 200, message = "Repositories list returned"),
       @ApiResponse(code = 401, message = AUTHENTICATION_REQUIRED),

--- a/components/nexus-repository/src/test/java/org/sonatype/nexus/repository/rest/api/RepositoriesApiResourceTest.java
+++ b/components/nexus-repository/src/test/java/org/sonatype/nexus/repository/rest/api/RepositoriesApiResourceTest.java
@@ -1,0 +1,80 @@
+package org.sonatype.nexus.repository.rest.api;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mock;
+import org.sonatype.goodies.testsupport.TestSupport;
+import org.sonatype.nexus.common.collect.NestedAttributesMap;
+import org.sonatype.nexus.repository.Format;
+import org.sonatype.nexus.repository.Repository;
+import org.sonatype.nexus.repository.Type;
+import org.sonatype.nexus.repository.config.Configuration;
+import org.sonatype.nexus.repository.rest.api.model.AbstractApiRepository;
+import org.sonatype.nexus.repository.types.HostedType;
+import org.sonatype.nexus.repository.types.ProxyType;
+
+import java.util.Collections;
+import java.util.Map;
+
+import static org.hamcrest.Matchers.is;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+import static org.junit.Assert.assertThat;
+
+public class RepositoriesApiResourceTest extends TestSupport {
+    private static final String REPOSITORY_1_NAME = "docker-local";
+    private static final Format REPOSITORY_1_FORMAT = new Format("docker") {};
+    private static final HostedType REPOSITORY_1_TYPE = new HostedType();
+    private static final String REPOSITORY_1_URL = "dockerUrl";
+    private Repository REPOSITORY_1;
+    private AbstractApiRepository ABSTRACT_API_REPOSITORY_1;
+
+    @Mock
+    private AuthorizingRepositoryManager authorizingRepositoryManager;
+
+    @Mock
+    private ApiRepositoryAdapter defaultAdapter;
+
+    private Map<String, ApiRepositoryAdapter> convertersByFormat = Collections.emptyMap();
+
+    private RepositoriesApiResource underTest;
+
+    @Before
+    public void setup() throws RepositoryNotFoundException {
+        REPOSITORY_1 = createMockRepository(REPOSITORY_1_NAME, REPOSITORY_1_FORMAT, REPOSITORY_1_TYPE, REPOSITORY_1_URL, null);
+        ABSTRACT_API_REPOSITORY_1 = createMockAbstractApiRepository();
+
+        when(authorizingRepositoryManager.getRepository("docker-local")).thenReturn(REPOSITORY_1);
+        when(defaultAdapter.adapt(REPOSITORY_1)).thenReturn(ABSTRACT_API_REPOSITORY_1);
+
+        underTest = new RepositoriesApiResource(authorizingRepositoryManager, defaultAdapter, convertersByFormat);
+    }
+
+    @Test
+    public void testGetRepository() {
+        assertThat(underTest.getRepository(REPOSITORY_1_NAME), is(ABSTRACT_API_REPOSITORY_1));
+    }
+
+    private static Repository createMockRepository(final String name, final Format format, final Type type,
+                                                   final String url, final String remoteUrl) {
+        Repository repository = mock(Repository.class);
+        when(repository.getName()).thenReturn(name);
+        when(repository.getFormat()).thenReturn(format);
+        when(repository.getType()).thenReturn(type);
+        when(repository.getUrl()).thenReturn(url);
+        Configuration configuration = mock(Configuration.class);
+        if (type instanceof ProxyType) {
+            when(configuration.attributes("proxy")).thenReturn(new NestedAttributesMap(
+                    "proxy",
+                    Collections.singletonMap(remoteUrl, remoteUrl)
+            ));
+        }
+        when(repository.getConfiguration()).thenReturn(configuration);
+        return repository;
+    }
+
+    private static AbstractApiRepository createMockAbstractApiRepository() {
+        AbstractApiRepository repository = mock(AbstractApiRepository.class);
+        return repository;
+    }
+}


### PR DESCRIPTION
There is currently only a REST endpoint to fetch all repositories, not one to get just a single known endpoint. This is useful for Desired State Configuration such as Terraform, Ansible, Chef, etc.