### PR TITLE
Fix proxy API request converter for http client auth

### DIFF
--- a/components/nexus-repository-services/src/main/java/org/sonatype/nexus/repository/rest/api/ProxyRepositoryApiRequestToConfigurationConverter.java
+++ b/components/nexus-repository-services/src/main/java/org/sonatype/nexus/repository/rest/api/ProxyRepositoryApiRequestToConfigurationConverter.java
@@ -70,17 +70,17 @@ public class ProxyRepositoryApiRequestToConfigurationConverter<T extends ProxyRe
       HttpClientConnectionAttributes connection = httpClient.getConnection();
       NestedAttributesMap connectionConfiguration = httpclientConfiguration.child("connection");
       convertConnection(connection, connectionConfiguration);
-      convertAuthentication(httpClient, connectionConfiguration);
+      convertAuthentication(httpClient, httpclientConfiguration);
     }
   }
 
   private void convertAuthentication(
       final HttpClientAttributes httpClient,
-      final NestedAttributesMap connectionConfiguration)
+      final NestedAttributesMap httpClientConfiguration)
   {
     HttpClientConnectionAuthenticationAttributes authentication = httpClient.getAuthentication();
     if (nonNull(authentication)) {
-      NestedAttributesMap authenticationConfiguration = connectionConfiguration.child("authentication");
+      NestedAttributesMap authenticationConfiguration = httpClientConfiguration.child("authentication");
       authenticationConfiguration.set("type", authentication.getType());
       authenticationConfiguration.set("username", authentication.getUsername());
       authenticationConfiguration.set("password", authentication.getPassword());


### PR DESCRIPTION
Authentication is part of of HTTP client configuration, not connection settings.

Creating/Updating proxy with authentication via the REST API ignore the settings.