### PR TITLE
NEXUS-23865 maven-metadata.xml forceRebuild flag not removed on rebuild

### DIFF
--- a/plugins/nexus-repository-maven/src/main/java/org/sonatype/nexus/repository/maven/internal/orient/MavenFacetImpl.java
+++ b/plugins/nexus-repository-maven/src/main/java/org/sonatype/nexus/repository/maven/internal/orient/MavenFacetImpl.java
@@ -253,6 +253,8 @@ public class MavenFacetImpl
     final StorageTx tx = UnitOfWork.currentTx();
 
     removeRebuildFlag(asset);
+    tx.saveAsset(asset);
+
     Blob metadataBlob = tx.requireBlob(asset.requireBlobRef());
     Metadata metadata = MavenModels.readMetadata(metadataBlob.getInputStream());
 


### PR DESCRIPTION
Fixes issue https://issues.sonatype.org/browse/NEXUS-23865

This issue can cause timeout errors when multiple parallel builds request one or more metadata files, all marked with the forceRebuildFlag.