### PR TITLE
Bump AWS SDK version to support IRSA

### DIFF
--- a/buildsupport/other/pom.xml
+++ b/buildsupport/other/pom.xml
@@ -28,7 +28,7 @@
   <packaging>pom</packaging>
 
   <properties>
-    <aws-java-sdk.version>1.11.201</aws-java-sdk.version>
+    <aws-java-sdk.version>1.11.704</aws-java-sdk.version>
   </properties>
 
   <dependencyManagement>


### PR DESCRIPTION
Resolves https://issues.sonatype.org/browse/NEXUS-24019

AWS EKS supports a built-in system for assigning IAM roles to pods, which requires the application running in said pod to be able to use sts:AssumeRoleWithWebIdentity method to assume the role specified in the service account annotation. This is useful for seamless nexus compatibility with AWS EKS.

https://docs.aws.amazon.com/eks/latest/userguide/iam-roles-for-service-accounts-minimum-sdk.html

AWS SDK supports it out of the box starting with version 1.11.704