### PR TITLE
NEXUS-21909: Configuring Anonymous via SecurityApi should disable Onboarding

### DIFF
--- a/components/nexus-security/src/main/java/org/sonatype/nexus/security/internal/SecurityApiImpl.groovy
+++ b/components/nexus-security/src/main/java/org/sonatype/nexus/security/internal/SecurityApiImpl.groovy
@@ -50,7 +50,7 @@ class SecurityApiImpl
   AnonymousConfiguration setAnonymousAccess(final boolean enabled) {
     AnonymousConfiguration anonymousConfiguration = anonymousManager.configuration
 
-    if (anonymousConfiguration.enabled != enabled) {
+    if (!anonymousManager.configured || anonymousConfiguration.enabled != enabled) {
       anonymousConfiguration.enabled = enabled
       anonymousManager.configuration = anonymousConfiguration
       log.info('Anonymous access configuration updated to: {}', anonymousConfiguration)

--- a/components/nexus-security/src/test/java/org/sonatype/nexus/security/internal/SecurityApiImplTest.groovy
+++ b/components/nexus-security/src/test/java/org/sonatype/nexus/security/internal/SecurityApiImplTest.groovy
@@ -51,9 +51,10 @@ class SecurityApiImplTest
       !updatedConfiguration.enabled
   }
 
-  def 'No save is made when anonymous settings already match'() {
+  def 'No save is made when configured and anonymous settings already match'() {
     given:
       def configuration = new TestAnonymousConfiguration(enabled: true)
+      anonymousManager.isConfigured() >> true
 
     when:
       def updatedConfiguration = api.setAnonymousAccess(true)
@@ -62,6 +63,20 @@ class SecurityApiImplTest
       1 * anonymousManager.getConfiguration() >> configuration
       0 * anonymousManager.setConfiguration(_)
       updatedConfiguration.enabled
+  }
+
+  def 'One save is made when unconfigured and anonymous settings already match'() {
+    given:
+      def configuration = new TestAnonymousConfiguration(enabled: false)
+      anonymousManager.isConfigured() >> false
+
+    when:
+      def updatedConfiguration = api.setAnonymousAccess(false)
+
+    then:
+      1 * anonymousManager.getConfiguration() >> configuration
+      1 * anonymousManager.setConfiguration(_)
+      !updatedConfiguration.enabled
   }
 
   def 'Can add a new User'() {


### PR DESCRIPTION
Ensure that using `SecurityApi.setAnonymous` explicitly sets the `AnonymousManager` configuration if it is not already configured, or else the onboarding wizard will still trigger.