### PR TITLE
use container with 8GB RAM, 4 CPUs.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,6 +4,7 @@ executors:
   my-executor:
     docker:
       - image: circleci/openjdk:8-jdk
+    resource_class: large
     working_directory: ~/nexus-public
     environment:
       MAVEN_OPTS: -Xmx3200m


### PR DESCRIPTION
This change should fix CI build failures due to: `Received "killed" signal` by increasing ram to 8GB and 4 CPUs.
see: https://circleci.com/docs/2.0/configuration-reference/#resource_class

An alternative approach is shown in PR #72.