### PR TITLE
decrease max memory for JVM.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,7 +6,7 @@ executors:
       - image: circleci/openjdk:8-jdk
     working_directory: ~/nexus-public
     environment:
-      MAVEN_OPTS: -Xmx3200m
+      MAVEN_OPTS: -Xmx2700m
       OPENSSL_CONF: /
 
 jobs:


### PR DESCRIPTION
An alternative to the approach taken in PR #71. Instead we limit the RAM the JVM can consume, which should leave more available for other build processes (e.g. yarn). Thanks to @mpiggott for the suggestion.

If this change solves the build issue, a similar PR will be made to the internal tree (and that change will overwrite this commit when the next synch occurs).