### PR TITLE
Fix hard deletion behavior

### DIFF
--- a/plugins/nexus-blobstore-s3/src/main/java/org/sonatype/nexus/blobstore/s3/internal/S3BlobStore.java
+++ b/plugins/nexus-blobstore-s3/src/main/java/org/sonatype/nexus/blobstore/s3/internal/S3BlobStore.java
@@ -119,8 +119,6 @@ public class S3BlobStore
 
   public static final int DEFAULT_EXPIRATION_IN_DAYS = 3;
 
-  public static final int NO_AUTOMATIC_EXPIRY_HARD_DELETE = 0;
-
   public static final String METADATA_FILENAME = "metadata.properties";
 
   public static final String TYPE_KEY = "type";
@@ -361,7 +359,7 @@ public class S3BlobStore
   }
 
   private boolean deleteByExpire() {
-    return getConfiguredExpirationInDays(blobStoreConfiguration) != NO_AUTOMATIC_EXPIRY_HARD_DELETE;
+    return getConfiguredExpirationInDays(blobStoreConfiguration) > 0;
   }
 
   private boolean expire(final BlobId blobId, final String reason) {


### PR DESCRIPTION
Do hard deletion when `expiration` is set to `-1`

 https://github.com/sonatype/nexus-public/blob/5e3b1a22604d36384e1f55ae3024682c90b11733/plugins/nexus-blobstore-s3/src/main/java/org/sonatype/nexus/blobstore/s3/rest/internal/model/S3BlobStoreApiBucket.java#L49

And keep the same behavior as `BucketManager`

https://github.com/sonatype/nexus-public/blob/5e3b1a22604d36384e1f55ae3024682c90b11733/plugins/nexus-blobstore-s3/src/main/java/org/sonatype/nexus/blobstore/s3/internal/BucketManager.java#L160