### PR TITLE
Encode colon in proxied asset's name 

### DIFF
--- a/components/nexus-repository-services/src/main/java/org/sonatype/nexus/repository/proxy/ProxyFacetSupport.java
+++ b/components/nexus-repository-services/src/main/java/org/sonatype/nexus/repository/proxy/ProxyFacetSupport.java
@@ -404,13 +404,14 @@ public abstract class ProxyFacetSupport
 
   protected Content fetch(String url, Context context, @Nullable Content stale) throws IOException {
     HttpClient client = httpClient.getHttpClient();
+    String normalizedUrl = url.replaceAll(":", "%3A");
 
     checkState(config.remoteUrl.isAbsolute(),
         "Invalid remote URL '%s' for proxy repository %s, please fix your configuration", config.remoteUrl,
         getRepository().getName());
     URI uri;
     try {
-      uri = config.remoteUrl.resolve(url);
+      uri = config.remoteUrl.resolve(normalizedUrl);
     }
     catch (IllegalArgumentException e) { // NOSONAR
       log.warn("Unable to resolve url. Reason: {}", e.getMessage());


### PR DESCRIPTION
Currently, when names or relative paths of proxied assets contain a colon (`:`), forwarding of the request fails:

```
nexus3_1  | 2020-07-19 21:56:57,573+0000 WARN  [qtp1665000230-434] *UNKNOWN org.sonatype.nexus.orient.raw.internal.RawProxyFacet - Exception org.apache.http.client.ClientProtocolException: URI does not specify a valid host name: ethtool-1:5.7-1-x86_64.pkg.tar.zst checking remote for update, proxy repo archlinux_x64-extra-proxy failed to fetch ethtool-1:5.7-1-x86_64.pkg.tar.zst, content not in cache.
```

This issue is caused by `ProxyFacetSupport#fetch(String, Context, Content)` using `URI#resolve(String)` to combine the upstream server's base url with the asset's name/path with the asset path not being url-encoded. Any url-encoding added by clients seems to be lost as well.

This causes trouble when asset names contain `:`. In this case, `URI#resolve` assumes the part in front of `:` would be the uri scheme followed by the authority part. Therefore resolve just returns the asset name/path without prepending the target base url as specified by [its javadoc](https://docs.oracle.com/javase/8/docs/api/java/net/URI.html#resolve-java.net.URI-).

To fix this, any colon in the asset's relative url must be encoded prior to calling `URI#resolve`.

A typical usecase that requires this fix is using the raw proxy feature to proxy an archlinux repository. Archlinux package names commonly contain colons in their names.