### PR TITLE
Url-encode colons in names of raw proxy assets

### DIFF
--- a/plugins/nexus-repository-raw/src/main/java/org/sonatype/nexus/orient/raw/internal/RawProxyFacet.java
+++ b/plugins/nexus-repository-raw/src/main/java/org/sonatype/nexus/orient/raw/internal/RawProxyFacet.java
@@ -50,7 +50,7 @@ public class RawProxyFacet
 
   @Override
   protected String getUrl(@Nonnull final Context context) {
-    return componentPath(context);
+    return componentPath(context).replaceAll(":", "%3A");
   }
 
   /**


### PR DESCRIPTION
Without encoding colons, resolving of upstream urls using [URI#resolve](https://docs.oracle.com/javase/8/docs/api/java/net/URI.html#resolve-java.net.URI-) (via ProxyFacetSupport#fetch) fails for components with names including colons: This is due to URI#resolve returning the given uri unchanged/unresolved if it is opaque or absolute. See [URI class reference](https://docs.oracle.com/javase/8/docs/api/java/net/URI.html) for details.

Unpatched nexus fails to resolve the upstream url of affected assets, leading to an error message like
```
nexus3_1  | 2020-07-19 21:56:57,573+0000 WARN  [qtp1665000230-434] *UNKNOWN org.sonatype.nexus.orient.raw.internal.RawProxyFacet - Exception org.apache.http.client.ClientProtocolException: URI does not specify a valid host name: ethtool-1:5.7-1-x86_64.pkg.tar.zst checking remote for update, proxy repo archlinux_x64-extra-proxy failed to fetch ethtool-1:5.7-1-x86_64.pkg.tar.zst, content not in cache.
``` 

I stumbled upon this issue when setting up a raw proxy repository for an upstream archlinux repository. Archlinux package file names commonly contain colons. 