### PR TITLE
feat(filters): Added SearchGolang Filter for NX.coreui.controller

### DIFF
--- a/plugins/nexus-coreui-plugin/src/main/resources/static/rapture/NX/coreui/app/PluginConfig.js
+++ b/plugins/nexus-coreui-plugin/src/main/resources/static/rapture/NX/coreui/app/PluginConfig.js
@@ -201,6 +201,12 @@ Ext.define('NX.coreui.app.PluginConfig', {
       }
     },
     {
+      id: 'NX.coreui.controller.SearchGolang',
+      active: function () {
+        return NX.app.Application.bundleActive('org.sonatype.nexus.plugins.nexus-repository-golang');
+      }
+    },
+    {
       id: 'NX.coreui.controller.SearchCocoapods',
       active: function () {
         return NX.app.Application.bundleActive('org.sonatype.nexus.plugins.nexus-repository-cocoapods');

--- a/plugins/nexus-coreui-plugin/src/main/resources/static/rapture/NX/coreui/controller/SearchGolang.js
+++ b/plugins/nexus-coreui-plugin/src/main/resources/static/rapture/NX/coreui/controller/SearchGolang.js
@@ -1,0 +1,45 @@
+/*
+ * Sonatype Nexus (TM) Open Source Version
+ * Copyright (c) 2008-present Sonatype, Inc.
+ * All rights reserved. Includes the third-party code listed at http://links.sonatype.com/products/nexus/oss/attributions.
+ *
+ * This program and the accompanying materials are made available under the terms of the Eclipse Public License Version 1.0,
+ * which accompanies this distribution and is available at http://www.eclipse.org/legal/epl-v10.html.
+ *
+ * Sonatype Nexus (TM) Professional Version is available from Sonatype, Inc. "Sonatype" and "Sonatype Nexus" are trademarks
+ * of Sonatype, Inc. Apache Maven is a trademark of the Apache Software Foundation. M2eclipse is a trademark of the
+ * Eclipse Foundation. All other trademarks are the property of their respective owners.
+ */
+
+/**
+ * global Ext, NX
+ * Go repository search contribution.
+ */
+Ext.define('NX.coreui.controller.SearchGolang', {
+  extend: 'NX.app.Controller',
+  requires: [
+    'NX.I18n'
+  ],
+
+  /**
+   * @override
+   */
+  init: function() {
+    var me = this,
+        search = me.getController('NX.coreui.controller.Search');
+
+    search.registerFilter({
+      id: 'go',
+      name: 'Go',
+      text: NX.I18n.get('SearchGolang_Text'),
+      description: NX.I18n.get('SearchGolang_Description'),
+      readOnly: true,
+      criterias: [
+        { id: 'format', value: 'go', hidden: true },
+        { id: 'name.raw' },
+        { id: 'version' },
+        { id: 'keyword' }
+      ]
+    }, me);
+  }
+});


### PR DESCRIPTION
Hi, Nexus is a very great private repositroy manager tool.
But during using this tool, I found that there is no default to provide search filter for go packages
it's not particularly convenient for searching go packages. So i create this PR to deal with this problem.