### PR TITLE
Fix maven2 path has double hash extension or .asc mix with hash extension parse error

### DIFF
--- a/plugins/nexus-repository-maven/src/main/java/org/sonatype/nexus/repository/maven/internal/Maven2MavenPathParser.java
+++ b/plugins/nexus-repository-maven/src/main/java/org/sonatype/nexus/repository/maven/internal/Maven2MavenPathParser.java
@@ -124,6 +124,14 @@ public class Maven2MavenPathParser
         }
       }
 
+      for (HashType hashType : HashType.values()) {
+        if (str.endsWith("." + hashType.getExt())) {
+          extSuffix.insert(0, "." + hashType.getExt());
+          str = str.substring(0, str.length() - (hashType.getExt().length() + 1));
+          break;
+        }
+      }
+
       if (str.endsWith(Constants.METADATA_FILENAME)) {
         return null;
       }

--- a/plugins/nexus-repository-maven/src/test/java/org/sonatype/nexus/repository/maven/internal/Maven2MavenPathParserMxTest.java
+++ b/plugins/nexus-repository-maven/src/test/java/org/sonatype/nexus/repository/maven/internal/Maven2MavenPathParserMxTest.java
@@ -56,7 +56,7 @@ public class Maven2MavenPathParserMxTest
   public static String[] CLASSIFIERS = {null, "single", "with-dash", "with.dot"};
 
   public static String[] EXTENSIONS = {
-      "jar", "jar.sha1", "jar.asc", "jar.asc.md5", "tar.gz",
+      "jar", "jar.sha1", "jar.asc", "jar.asc.md5", "pom.md5.asc", "jar.md5.sha1", "jar.sha1.md5", "tar.gz",
       "tar.anyext.sha1", "tar.anyext.md5", "tar.anyext.asc", "tar.anyext.asc.md5",
       "cpio.anyext.sha1", "cpio.anyext.md5", "cpio.anyext.asc", "cpio.anyext.asc.md5",
       "nk.os.sha1", "nk.os.md5", "nk.os.asc", "nk.os.asc.md5"

--- a/plugins/nexus-repository-maven/src/test/java/org/sonatype/nexus/repository/maven/internal/Maven2MavenPathParserTest.java
+++ b/plugins/nexus-repository-maven/src/test/java/org/sonatype/nexus/repository/maven/internal/Maven2MavenPathParserTest.java
@@ -324,6 +324,34 @@ public class Maven2MavenPathParserTest
     assertThat(mavenPath.getCoordinates().getClassifier(), equalTo("some.strange.classifier"));
     assertThat(mavenPath.getCoordinates().getExtension(), equalTo("pom.asc.sha1"));
     assertThat(mavenPath.getCoordinates().getSignatureType(), equalTo(SignatureType.GPG));
+
+    mavenPath = pathParser.parsePath("/com/google/code/findbugs/jsr305/1.3.9/jsr305-1.3.9.pom.md5.sha1");
+    assertThat(mavenPath, notNullValue());
+    assertThat(mavenPath.getFileName(), equalTo("jsr305-1.3.9.pom.md5.sha1"));
+    assertThat(mavenPath.getPath(), equalTo("com/google/code/findbugs/jsr305/1.3.9/jsr305-1.3.9.pom.md5.sha1"));
+    assertThat(mavenPath.getHashType(), equalTo(HashType.SHA1));
+    assertThat(mavenPath.getCoordinates(), notNullValue());
+    assertThat(mavenPath.getCoordinates().getGroupId(), equalTo("com.google.code.findbugs"));
+    assertThat(mavenPath.getCoordinates().getArtifactId(), equalTo("jsr305"));
+    assertThat(mavenPath.getCoordinates().getVersion(), equalTo("1.3.9"));
+    assertThat(mavenPath.getCoordinates().getBaseVersion(), equalTo("1.3.9"));
+    assertThat(mavenPath.getCoordinates().getClassifier(), nullValue());
+    assertThat(mavenPath.getCoordinates().getExtension(), equalTo("pom.md5.sha1"));
+    assertThat(mavenPath.getCoordinates().getSignatureType(), nullValue());
+
+    mavenPath = pathParser.parsePath("/com/netflix/spectator/spectator-ext-ipc/0.103.0/spectator-ext-ipc-0.103.0.pom.md5.asc");
+    assertThat(mavenPath, notNullValue());
+    assertThat(mavenPath.getFileName(), equalTo("spectator-ext-ipc-0.103.0.pom.md5.asc"));
+    assertThat(mavenPath.getPath(), equalTo("com/netflix/spectator/spectator-ext-ipc/0.103.0/spectator-ext-ipc-0.103.0.pom.md5.asc"));
+    assertThat(mavenPath.getHashType(), nullValue());
+    assertThat(mavenPath.getCoordinates(), notNullValue());
+    assertThat(mavenPath.getCoordinates().getGroupId(), equalTo("com.netflix.spectator"));
+    assertThat(mavenPath.getCoordinates().getArtifactId(), equalTo("spectator-ext-ipc"));
+    assertThat(mavenPath.getCoordinates().getVersion(), equalTo("0.103.0"));
+    assertThat(mavenPath.getCoordinates().getBaseVersion(), equalTo("0.103.0"));
+    assertThat(mavenPath.getCoordinates().getClassifier(), nullValue());
+    assertThat(mavenPath.getCoordinates().getExtension(), equalTo("pom.md5.asc"));
+    assertThat(mavenPath.getCoordinates().getSignatureType(), equalTo(SignatureType.GPG));
   }
 
   @Test


### PR DESCRIPTION
**The url resource for test**:

https://repo1.maven.org/maven2/com/netflix/spectator/spectator-ext-jvm/0.103.0/spectator-ext-jvm-0.103.0.module.md5.asc

**Here is the exception log**:

`2020-10-28 10:57:58,623+0800 WARN  [qtp716471188-527] *UNKNOWN org.sonatype.nexus.repository.httpbridge.internal.ViewServlet - Failure servicing: GET /maven2/com/netflix/spectator/spectator-ext-jvm/0.103.0/spectator-ext-jvm-0.103.0.module.md5.asc
java.lang.StringIndexOutOfBoundsException: String index out of range: -1
	at java.lang.String.substring(String.java:1967)
	at org.sonatype.nexus.repository.maven.MavenPath.subordinateOf(MavenPath.java:288)
	at org.sonatype.nexus.repository.maven.MavenPath.main(MavenPath.java:265)
	at org.sonatype.nexus.repository.maven.internal.Maven2MavenPathParser.isRepositoryMetadata(Maven2MavenPathParser.java:70)
	at org.sonatype.nexus.repository.maven.internal.orient.MavenProxyFacet.getCacheController(MavenProxyFacet.java:79)
	at org.sonatype.nexus.repository.proxy.ProxyFacetSupport.fetch(ProxyFacetSupport.java:440)
	at org.sonatype.nexus.repository.proxy.ProxyFacetSupport.fetch(ProxyFacetSupport.java:402)
	at org.sonatype.nexus.repository.maven.internal.orient.MavenProxyFacet.fetch(MavenProxyFacet.java:74)
	at org.sonatype.nexus.repository.proxy.ProxyFacetSupport.doGet(ProxyFacetSupport.java:269)
	at org.sonatype.nexus.repository.proxy.ProxyFacetSupport.lambda$1(ProxyFacetSupport.java:245)
	at org.sonatype.nexus.common.io.CooperatingFuture.performCall(CooperatingFuture.java:122)
	at org.sonatype.nexus.common.io.CooperatingFuture.call(CooperatingFuture.java:64)
	at org.sonatype.nexus.common.io.ScopedCooperationFactorySupport$ScopedCooperation.cooperate(ScopedCooperationFactorySupport.java:99)
`

In my opinion, this pr may be the smallest change of code, but maybe not the best solution.

If you have some other ideas, welcome to discuss with me.

Thanks for review.