### PR TITLE
Prevent possible NPE in pypi repo upgrade

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,5 @@ out
 # Zion
 .zion/
 variables.properties
+node_modules
+dist

--- a/plugins/nexus-repository-pypi/src/main/java/org/sonatype/nexus/repository/pypi/upgrade/PypiUpgrade_1_1.java
+++ b/plugins/nexus-repository-pypi/src/main/java/org/sonatype/nexus/repository/pypi/upgrade/PypiUpgrade_1_1.java
@@ -106,27 +106,26 @@ public class PypiUpgrade_1_1
         OIndex<?> bucketIdx = db.getMetadata().getIndexManager().getIndex(I_REPOSITORY_NAME);
         pypiRepositoryNames.forEach(repositoryName -> {
           log.info("Scanning pypi repository {} for index file assets", repositoryName);
-          OIdentifiable bucket = (OIdentifiable) bucketIdx.get(repositoryName);
+          OIdentifiable bucket = bucketIdx != null ? (OIdentifiable) bucketIdx.get(repositoryName) : null;
           if (bucket == null) {
             log.warn("Unable to find bucket for {}", repositoryName);
-          }
-          else {
-            // Deleting index files
-            int deletes = db.command(deleteIndexCommand).execute(bucket.getIdentity());
-            if (deletes > 0) {
-              log.info(
-                  "Deleted {} pypi index asset(s) in repository {}: ", deletes, repositoryName);
-            }
-
-            if (db.getMetadata().getSchema().existsClass(BROWSE_NODE_CLASS)) {
-              // Deleting browse nodes
-              deletes = db.command(deleteBrowseNodesCommand).execute(repositoryName);
-              if (deletes > 0) {
+          } else {
+             // Deleting index files
+             int deletes = db.command(deleteIndexCommand).execute(bucket.getIdentity());
+             if (deletes > 0) {
                 log.info(
-                    "Deleted {} browse node(s) in repository {}", deletes, repositoryName);
-              }
-            }
+                    "Deleted {} pypi index asset(s) in repository {}: ", deletes, repositoryName);
+             }
           }
+
+          if (db.getMetadata().getSchema().existsClass(BROWSE_NODE_CLASS)) {
+             // Deleting browse nodes
+             int deletes = db.command(deleteBrowseNodesCommand).execute(repositoryName);
+             if (deletes > 0) {
+                log.info(
+                     "Deleted {} browse node(s) in repository {}", deletes, repositoryName);
+             }
+           }
         });
       }
     }


### PR DESCRIPTION
I hit an NPE when upgrading from 3.16 to 3.21 or 3.30. The NPE happens when upgrading a pypi repo, when the index cannot be located.

This fix simply skips deleting the index, if its not found. I have verified that this allows the upgrade to proceed in our environment.

See this bug report for more details on the issue. https://issues.sonatype.org/browse/NEXUS-27536