### PR TITLE
[NEXUS-29524] Fixes DMG files upload to Raw Repo with content type validation ON

### DIFF
--- a/components/nexus-repository-services/src/main/java/org/sonatype/nexus/repository/mime/DefaultContentValidator.java
+++ b/components/nexus-repository-services/src/main/java/org/sonatype/nexus/repository/mime/DefaultContentValidator.java
@@ -72,7 +72,7 @@ public class DefaultContentValidator
       contentDetectedMimeTypes.addAll(mimeSupport.detectMimeTypes(is, contentName));
     }
     adjustIfHtml(contentDetectedMimeTypes);
-    log.debug("Mime support detects {} as {}", contentName, contentDetectedMimeTypes);
+    log.info("Mime support detects {} as {}", contentName, contentDetectedMimeTypes);
 
     if (strictContentTypeValidation && isUnknown(contentDetectedMimeTypes)) {
       throw new InvalidContentException("Content type could not be determined: " + contentName);
@@ -86,12 +86,16 @@ public class DefaultContentValidator
               mimeRulesSource != null ? mimeRulesSource : MimeRulesSource.NOOP)
       );
       adjustIfHtml(nameAssumedMimeTypes);
-      log.debug("Mime support assumes {} as {}", contentName, nameAssumedMimeTypes);
+      log.info("Mime support assumes {} as {} {}", contentName, nameAssumedMimeTypes);
 
       if (!isUnknown(nameAssumedMimeTypes)) {
         Set<String> intersection = Sets.intersection(contentDetectedMimeTypes, nameAssumedMimeTypes);
         log.debug("content/name types intersection {}", intersection);
-        if (strictContentTypeValidation && intersection.isEmpty()) {
+        if ( strictContentTypeValidation && intersection.isEmpty()
+              && !("[application/x-apple-diskimage]".equals(nameAssumedMimeTypes.toString())
+                 && ( "[application/x-bzip]".equals(contentDetectedMimeTypes.toString())
+                     || "[application/zlib]".equals(contentDetectedMimeTypes.toString())) )
+                        ) {
           throw new InvalidContentException(
               String.format("Detected content type %s, but expected %s: %s",
                   contentDetectedMimeTypes, nameAssumedMimeTypes, contentName)


### PR DESCRIPTION
Fixes [NEXUS-29524](https://issues.sonatype.org/browse/NEXUS-29524) failure of DMG files upload to Raw Repositories with Strict content type validation set ON.

This exception for DMG files comparing expected DMG file mime type with the detected mime type.

**Tested** upload with local Nexus3  installation.


_NB:
Better solution would be to fix used [Apache Tika](https://github.com/apache/tika) component to detect mime type of OCX DMG files correctly. Related Apache Tika issue is [TIKA-3590](https://issues.apache.org/jira/browse/TIKA-3590)._