### PR TITLE
Fix incompatibility with xstream 1.4.18

### DIFF
--- a/components/nexus-client-core/src/main/java/org/sonatype/nexus/client/internal/rest/XStreamXmlProvider.java
+++ b/components/nexus-client-core/src/main/java/org/sonatype/nexus/client/internal/rest/XStreamXmlProvider.java
@@ -28,10 +28,13 @@ import javax.ws.rs.core.MultivaluedMap;
 import javax.ws.rs.ext.Provider;
 
 import org.sonatype.nexus.client.internal.util.Check;
+import org.sonatype.nexus.rest.model.NexusResponse;
 
 import com.sun.jersey.core.provider.AbstractMessageReaderWriterProvider;
 import com.thoughtworks.xstream.XStream;
 import com.thoughtworks.xstream.io.xml.CompactWriter;
+import com.thoughtworks.xstream.security.TypeHierarchyPermission;
+import com.thoughtworks.xstream.security.WildcardTypePermission;
 
 /**
  * Jersey provider that uses XStream, as we want to use the same tech (as we have all the config bits already) on
@@ -52,6 +55,9 @@ public class XStreamXmlProvider
   private final XStream xstream;
 
   public XStreamXmlProvider(final XStream xstream, final MediaType xstreamMediaType) {
+    xstream.addPermission(new TypeHierarchyPermission(NexusResponse.class));
+    xstream.addPermission(new WildcardTypePermission(new String[]{"com.sonatype.nexus.staging.api.dto.*"}));
+
     this.xstream = Check.notNull(xstream, XStream.class);
     this.xstreamMediaType = Check.notNull(xstreamMediaType, MediaType.class);
   }


### PR DESCRIPTION
This change adds necessary xstream permissions so we can deserialize Nexus XML responses using the nexus-maven-plugin when using a dependency declaration like this:

```
<plugin>
  <groupId>org.sonatype.plugins</groupId>
  <artifactId>nexus-staging-maven-plugin</artifactId>
  <version>1.6.8</version>
  <dependencies>
    <dependency>
      <groupId>org.sonatype.nexus</groupId>
      <artifactId>nexus-client-core</artifactId>
      <version>2.14.21-02</version>
    </dependency>
    <dependency>
      <groupId>com.thoughtworks.xstream</groupId>
      <artifactId>xstream</artifactId>
      <version>1.4.18</version>
    </dependency>
    <dependency><!-- needed by xstream 1.4.16 -->
      <groupId>xpp3</groupId>
      <artifactId>xpp3</artifactId>
      <version>1.1.4c</version>
    </dependency>
    <dependency>
      <groupId>org.apache.httpcomponents</groupId>
      <artifactId>httpclient</artifactId>
      <version>4.5.13</version>
    </dependency>
    <dependency>
      <groupId>org.apache.httpcomponents</groupId>
      <artifactId>httpcore</artifactId>
      <version>4.4.15</version>
    </dependency>
    <dependency>
      <groupId>ch.qos.logback</groupId>
      <artifactId>logback-classic</artifactId>
      <version>1.2.9</version>
    </dependency>
    <dependency>
      <groupId>ch.qos.logback</groupId>
      <artifactId>logback-core</artifactId>
      <version>1.2.9</version>
    </dependency>
  </dependencies>
</plugin>
```

Also see https://github.com/x-stream/xstream/issues/263