### PR TITLE
Content-Security-Policy allow user triggered downloads

### DIFF
--- a/plugins/nexus-repository-httpbridge/src/main/java/org/sonatype/nexus/repository/httpbridge/internal/ViewServlet.java
+++ b/plugins/nexus-repository-httpbridge/src/main/java/org/sonatype/nexus/repository/httpbridge/internal/ViewServlet.java
@@ -65,7 +65,7 @@ public class ViewServlet
 {
   private static final Logger log = LoggerFactory.getLogger(ViewServlet.class);
 
-  private static final String SANDBOX = "sandbox allow-forms allow-modals allow-popups allow-presentation allow-scripts allow-top-navigation";
+  private static final String SANDBOX = "sandbox allow-forms allow-modals allow-popups allow-presentation allow-scripts allow-top-navigation allow-downloads";
 
   @VisibleForTesting
   static final String P_DESCRIBE = "describe";

--- a/plugins/nexus-repository-httpbridge/src/test/java/org/sonatype/nexus/repository/httpbridge/internal/ViewServletTest.java
+++ b/plugins/nexus-repository-httpbridge/src/test/java/org/sonatype/nexus/repository/httpbridge/internal/ViewServletTest.java
@@ -184,7 +184,7 @@ public class ViewServletTest
     underTest.service(httpServletRequest, servletResponse);
 
     verify(servletResponse).setHeader(HttpHeaders.CONTENT_SECURITY_POLICY,
-        "sandbox allow-forms allow-modals allow-popups allow-presentation allow-scripts allow-top-navigation");
+        "sandbox allow-forms allow-modals allow-popups allow-presentation allow-scripts allow-top-navigation allow-downloads");
   }
 
   @Test


### PR DESCRIPTION
There is an open issue on redoc that is not allowing to download the specification when published on nexus.
https://github.com/Redocly/redoc/issues/1902

Issue:
![image](https://user-images.githubusercontent.com/3091122/157208142-27d88dd8-d8bf-4244-84f1-59d3be1bae05.png)

This fix fixes the downloading of generated specification from ReDoc and published on nexus as html.

https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/sandbox
