### PR TITLE
limit max workers for jest to help with CI build resource failure

### DIFF
--- a/plugins/nexus-coreui-plugin/src/frontend/jest.config.js
+++ b/plugins/nexus-coreui-plugin/src/frontend/jest.config.js
@@ -18,6 +18,9 @@
 // https://jestjs.io/docs/en/configuration.html
 
 module.exports = {
+  // Fix Memory problems with jest and workers on CircleCI (public) build
+  maxWorkers: 2,
+
   // All imported modules in your tests should be mocked automatically
   // automock: false,
 


### PR DESCRIPTION
Trying to avoid exhaustion of CPU/RAM during CI build while building the `nexus-coreui-plugin` sub-module.

This article implies a possible solution: https://discuss.circleci.com/t/memory-problems-with-jest-and-workers/10297

Any thoughts on if this PR is making the change in the correct place?