### PR TITLE
Avoid NPE when using new status code

### DIFF
--- a/components/nexus-base/src/main/java/org/sonatype/nexus/internal/web/ErrorPageServlet.java
+++ b/components/nexus-base/src/main/java/org/sonatype/nexus/internal/web/ErrorPageServlet.java
@@ -139,7 +139,10 @@ public class ErrorPageServlet
 
     TemplateParameters params = templateHelper.parameters();
     params.set("errorCode", errorCode);
-    params.set("errorName", Status.fromStatusCode(errorCode).getReasonPhrase());
+    Status errorStatusCode = Status.fromStatusCode(errorCode);
+    if (errorStatusCode != null) {
+      params.set("errorName", errorStatusCode.getReasonPhrase());
+    }
     params.set("errorDescription", errorDescription);
 
     // add cause if ?debug enabled and there is an exception


### PR DESCRIPTION
Some status code such as 451 doesn't exists in Status enum. It cause a NullPointerException that make the response 500.