### PR TITLE
Add sha256 checksums to assets in raw repositories

### DIFF
--- a/plugins/nexus-repository-raw/src/main/java/org/sonatype/nexus/blobstore/restore/raw/internal/orient/OrientRawRestoreBlobStrategy.java
+++ b/plugins/nexus-repository-raw/src/main/java/org/sonatype/nexus/blobstore/restore/raw/internal/orient/OrientRawRestoreBlobStrategy.java
@@ -38,6 +38,7 @@ import com.google.common.collect.ImmutableList;
 
 import static org.sonatype.nexus.common.hash.HashAlgorithm.MD5;
 import static org.sonatype.nexus.common.hash.HashAlgorithm.SHA1;
+import static org.sonatype.nexus.common.hash.HashAlgorithm.SHA256;
 import static org.sonatype.nexus.repository.storage.MetadataNodeEntityAdapter.P_NAME;
 
 /**
@@ -63,7 +64,7 @@ public class OrientRawRestoreBlobStrategy
 
   @Override
   protected List<HashAlgorithm> getHashAlgorithms() {
-    return ImmutableList.of(SHA1, MD5);
+    return ImmutableList.of(SHA256, SHA1, MD5);
   }
 
   @Override

--- a/plugins/nexus-repository-raw/src/main/java/org/sonatype/nexus/content/raw/RawContentFacet.java
+++ b/plugins/nexus-repository-raw/src/main/java/org/sonatype/nexus/content/raw/RawContentFacet.java
@@ -27,6 +27,7 @@ import com.google.common.collect.ImmutableList;
 
 import static org.sonatype.nexus.common.hash.HashAlgorithm.MD5;
 import static org.sonatype.nexus.common.hash.HashAlgorithm.SHA1;
+import static org.sonatype.nexus.common.hash.HashAlgorithm.SHA256;
 
 /**
  * Provides persistent content for the 'raw' format.
@@ -37,7 +38,7 @@ import static org.sonatype.nexus.common.hash.HashAlgorithm.SHA1;
 public interface RawContentFacet
     extends ContentFacet
 {
-  public final Iterable<HashAlgorithm> HASHING = ImmutableList.of(MD5, SHA1);
+  public final Iterable<HashAlgorithm> HASHING = ImmutableList.of(MD5, SHA1, SHA256);
 
   Optional<Content> get(String path) throws IOException;
 

--- a/plugins/nexus-repository-raw/src/main/java/org/sonatype/nexus/orient/raw/internal/RawContentFacetImpl.java
+++ b/plugins/nexus-repository-raw/src/main/java/org/sonatype/nexus/orient/raw/internal/RawContentFacetImpl.java
@@ -52,6 +52,7 @@ import com.google.common.collect.ImmutableList;
 import static com.google.common.base.Preconditions.checkNotNull;
 import static org.sonatype.nexus.common.hash.HashAlgorithm.MD5;
 import static org.sonatype.nexus.common.hash.HashAlgorithm.SHA1;
+import static org.sonatype.nexus.common.hash.HashAlgorithm.SHA256;
 import static org.sonatype.nexus.repository.storage.MetadataNodeEntityAdapter.P_NAME;
 
 /**
@@ -64,7 +65,7 @@ public class RawContentFacetImpl
     extends FacetSupport
     implements RawContentFacet
 {
-  public static final List<HashAlgorithm> HASH_ALGORITHMS = ImmutableList.of(MD5, SHA1);
+  public static final List<HashAlgorithm> HASH_ALGORITHMS = ImmutableList.of(MD5, SHA1, SHA256);
 
   private final AssetEntityAdapter assetEntityAdapter;
 

--- a/plugins/nexus-repository-raw/src/test/java/org/sonatype/nexus/blobstore/restore/raw/internal/orient/OrientRawRestoreBlobStrategyTest.java
+++ b/plugins/nexus-repository-raw/src/test/java/org/sonatype/nexus/blobstore/restore/raw/internal/orient/OrientRawRestoreBlobStrategyTest.java
@@ -57,6 +57,7 @@ import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.when;
 import static org.sonatype.nexus.common.hash.HashAlgorithm.MD5;
 import static org.sonatype.nexus.common.hash.HashAlgorithm.SHA1;
+import static org.sonatype.nexus.common.hash.HashAlgorithm.SHA256;
 
 public class OrientRawRestoreBlobStrategyTest
     extends TestSupport
@@ -191,7 +192,7 @@ public class OrientRawRestoreBlobStrategyTest
   public void testRestoreCreatesAssetFromBlobWithExpectedHashes() throws Exception {
     ArgumentCaptor<AssetBlob> assetBlobCaptor = ArgumentCaptor.forClass(AssetBlob.class);
 
-    Map<HashAlgorithm, HashCode> expectedHashes = Stream.of(SHA1, MD5)
+    Map<HashAlgorithm, HashCode> expectedHashes = Stream.of(SHA256, SHA1, MD5)
         .collect(toMap(identity(), algorithm -> algorithm.function().hashBytes(BLOB_BYTES)));
 
     underTest.restore(properties, blob, blobStore, !DRY_RUN);


### PR DESCRIPTION
SHA256 checksums aren't added to assets in a raw-format if uploaded via the API. It does work if you upload it through the gui though. This fixes this (I hope).

See also: https://issues.sonatype.org/browse/NEXUS-20827?focusedCommentId=817066&page=com.atlassian.jira.plugin.system.issuetabpanels%3Acomment-tabpanel#comment-817066