### PR TITLE
Fix/nexus 35266

### DIFF
--- a/components/nexus-repository-content/src/main/java/org/sonatype/nexus/repository/content/rest/AssetXOBuilder.java
+++ b/components/nexus-repository-content/src/main/java/org/sonatype/nexus/repository/content/rest/AssetXOBuilder.java
@@ -72,7 +72,6 @@ public class AssetXOBuilder
         .format(format)
         .contentType(contentType)
         .lastModified(lastModified)
-        .lastDownloaded(getLastDownloaded(asset))
         .attributes(getExpandedAttributes(asset, format, assetDescriptors))
         .uploader(uploader)
         .uploaderIp(uploaderIp)

--- a/components/nexus-repository-services/src/main/java/org/sonatype/nexus/repository/rest/api/AssetXO.groovy
+++ b/components/nexus-repository-services/src/main/java/org/sonatype/nexus/repository/rest/api/AssetXO.groovy
@@ -58,8 +58,6 @@ class AssetXO
 
   Date lastModified
 
-  Date lastDownloaded
-
   String uploader
 
   String uploaderIp


### PR DESCRIPTION
**lastDownloaded** variable, declared as member of class **AssetXO** isn't initialised.

Which leads to 2 unwanted behavior :

- var value is always _null_,
- the output isn't json compliant. As **lastDownloaded** is also contained in **Map attributes**.

Jira issue : https://issues.sonatype.org/browse/NEXUS-35266