### PR TITLE
Bump up JNA to 5.12.0

### DIFF
--- a/buildsupport/db/pom.xml
+++ b/buildsupport/db/pom.xml
@@ -199,13 +199,13 @@
       <dependency>
         <groupId>net.java.dev.jna</groupId>
         <artifactId>jna</artifactId>
-        <version>5.11.0</version>
+        <version>5.12.0</version>
       </dependency>
 
       <dependency>
         <groupId>net.java.dev.jna</groupId>
         <artifactId>jna-platform</artifactId>
-        <version>5.11.0</version>
+        <version>5.12.0</version>
       </dependency>
 
     </dependencies>


### PR DESCRIPTION
This PR want to bump up JNA to 5.10.0. The primary reason for this upgrade is to suppport LoongArch. JNA supports LoongArch from 5.12.0: https://github.com/java-native-access/jna/commit/0066b080d665dc51a41d52263d011f03c7eac9ea. Currently, using nexus on LoongArch results in an error that JNA does not support LoongArch