### PR TITLE
NEXUS-31461 fix(search): handle double or date.time part in qualifier numberPart

### DIFF
--- a/plugins/nexus-repository-maven/src/main/java/org/sonatype/nexus/repository/maven/internal/search/MavenVersionNormalizer.java
+++ b/plugins/nexus-repository-maven/src/main/java/org/sonatype/nexus/repository/maven/internal/search/MavenVersionNormalizer.java
@@ -63,7 +63,7 @@ public class MavenVersionNormalizer
   // major + minor + patch
   private static final int VERSION_LENGTH = 3;
 
-  private static final Pattern ALPHA_PLUS_NUMERIC_PATTERN = Pattern.compile("([^\\d-.]+)-?(\\d+)-?(\\w*)");
+  private static final Pattern ALPHA_PLUS_NUMERIC_PATTERN = Pattern.compile("([^\\d-.]+)-?([\\d.]+)-?(\\w*)");
 
   public static final String ALPHA = "alpha";
 

--- a/plugins/nexus-repository-maven/src/test/java/org/sonatype/nexus/repository/maven/internal/search/MavenVersionNormalizerTest.java
+++ b/plugins/nexus-repository-maven/src/test/java/org/sonatype/nexus/repository/maven/internal/search/MavenVersionNormalizerTest.java
@@ -129,9 +129,20 @@ public class MavenVersionNormalizerTest
     assertEquals("asparagus.schoolbus", underTest.getNormalizedVersion("asparagus.schoolbus"));
     assertEquals("000000001.000000002.000000003.000000004.000000005", underTest.getNormalizedVersion("1.2.3.4.5"));
     assertEquals("develop-020211201.000171404-000000903", underTest.getNormalizedVersion("develop-20211201.171404-903"));
+    assertEquals("javaMaven-000000000.000000004.000000000-020230506.000135309-000000009", underTest.getNormalizedVersion("javaMaven-0.4.0-20230506.135309-9"));
+    assertEquals("000000001.000000001.000000049.b.develop-020230308.000153857-000000022",
+            underTest.getNormalizedVersion("1.1.49.develop-20230308.153857-22"));
+
+    assertEquals("000000001.000000008.000000000.b.build_and_publish_docker_image-020230308.000153857-000000022",
+            underTest.getNormalizedVersion("1.8.0-build_and_publish_docker_image-20230308.153857-22"));
 
     assertInOrder("develop-20211130.182421-895", "develop-20211130.203249-896", "develop-20211201.111154-898",
         "develop-20211202.180605-904");
+    assertInOrder("javaMaven-0.4.0-20230506.135309-8", "javaMaven-0.4.0-20230506.135309-9");
+
+    assertInOrder("1.1.49.develop-20230308.153857-22", "1.1.49.develop-20230308.153857-23");
+    assertInOrder("1.8.0-build_and_publish_docker_image-20230308.153857-1", "1.8.0-build_and_publish_docker_image-20230308.153857-2",
+            "1.8.0-build_and_publish_docker_image-20230308.153857-10", "1.8.0-build_and_publish_docker_image-20230308.153857-11");
   }
 
   private void assertInOrder(String... versions) {


### PR DESCRIPTION
Fix for [NEXUS-31461](https://issues.sonatype.org/browse/NEXUS-31461)

When working with snapshot version when type is unedefined, the sort of all versions was not correct.

The format in nexus for snapshot could be in format x.x.x-qualifier-qualifier_numeric-suffix with qualifier_numeric could be
date.hour as in the following example: 

1.31-us_481184_luigi__migration_2-20220312.160843-37

The fix consist in handling "." in the qualifier_numeric part.


[NEXUS-31461]: https://sonatype-sandbox-840.atlassian.net/browse/NEXUS-31461?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ