### PR TITLE
remove ref to issues.sonatype.org from issue-template.md

### DIFF
--- a/.github/ISSUE_TEMPLATE/issue-template.md
+++ b/.github/ISSUE_TEMPLATE/issue-template.md
@@ -13,8 +13,6 @@ Sonatype Nexus Repository Pro customers should not use this form - please go to 
 
 If you believe you have found a security vulnerability, please use our [Bug Bounty Program](https://www.sonatype.com/report-a-security-vulnerability) to disclose responsibly.
 
-If you have a question about or an issue with publishing open source artifacts to Maven Central, please use the [OSSRH Issue Tracker](https://issues.sonatype.org/browse/OSSRH) instead.
-
 Thanks for creating an issue! Please fill out this form so we can be sure to have all the information we need, and to minimize back and forth.
 
 * What problem are you trying to solve?


### PR DESCRIPTION
issues.sonatype.org is no more:

> On Jan 9th, 2024 we announced issues.sonatype.org will be decommissioned soon. As part of the decommissioning process we removed the access to issues.sonatype.org, and we replaced our Jira ticketing system with a Zendesk email intake method. To open a support ticket with us email Central Support and follow-up in the email thread. To help us get back to you faster, please do not include previous replies in your follow-up messages.
https://central.sonatype.org/faq/what-happened-to-issues-sonatype-org/