### PR TITLE
Add Google Application Default Credentials as a proxy auth mechanism

### DIFF
--- a/buildsupport/other/pom.xml
+++ b/buildsupport/other/pom.xml
@@ -63,6 +63,12 @@
       </dependency>
 
       <dependency>
+        <groupId>com.google.auth</groupId>
+        <artifactId>google-auth-library-oauth2-http</artifactId>
+        <version>1.23.0</version>
+      </dependency>
+      
+      <dependency>
         <groupId>com.google.code.findbugs</groupId>
         <artifactId>jsr305</artifactId>
         <version>3.0.0</version>

--- a/components/nexus-core/src/main/java/org/sonatype/nexus/internal/httpclient/AuthenticationConfigurationDeserializer.java
+++ b/components/nexus-core/src/main/java/org/sonatype/nexus/internal/httpclient/AuthenticationConfigurationDeserializer.java
@@ -16,6 +16,7 @@ import java.io.IOException;
 
 import org.sonatype.nexus.httpclient.config.AuthenticationConfiguration;
 import org.sonatype.nexus.httpclient.config.BearerTokenAuthenticationConfiguration;
+import org.sonatype.nexus.httpclient.config.GoogleAuthenticationConfiguration;
 import org.sonatype.nexus.httpclient.config.NtlmAuthenticationConfiguration;
 import org.sonatype.nexus.httpclient.config.UsernameAuthenticationConfiguration;
 import org.sonatype.nexus.security.PasswordHelper;
@@ -85,6 +86,10 @@ public class AuthenticationConfigurationDeserializer
     else if (BearerTokenAuthenticationConfiguration.class.equals(type)) {
       BearerTokenAuthenticationConfiguration btac = (BearerTokenAuthenticationConfiguration) configuration;
       btac.setBearerToken(passwordHelper.tryDecrypt(btac.getBearerToken()));
+    }
+    else if (GoogleAuthenticationConfiguration.class.equals(type)) {
+      GoogleAuthenticationConfiguration gac = (GoogleAuthenticationConfiguration)configuration;
+      // nothing to set really.
     }
     return configuration;
   }

--- a/components/nexus-core/src/main/java/org/sonatype/nexus/internal/httpclient/AuthenticationConfigurationSerializer.java
+++ b/components/nexus-core/src/main/java/org/sonatype/nexus/internal/httpclient/AuthenticationConfigurationSerializer.java
@@ -16,6 +16,7 @@ import java.io.IOException;
 
 import org.sonatype.nexus.httpclient.config.AuthenticationConfiguration;
 import org.sonatype.nexus.httpclient.config.BearerTokenAuthenticationConfiguration;
+import org.sonatype.nexus.httpclient.config.GoogleAuthenticationConfiguration;
 import org.sonatype.nexus.httpclient.config.NtlmAuthenticationConfiguration;
 import org.sonatype.nexus.httpclient.config.UsernameAuthenticationConfiguration;
 import org.sonatype.nexus.security.PasswordHelper;
@@ -72,6 +73,9 @@ public class AuthenticationConfigurationSerializer
     else if (value instanceof BearerTokenAuthenticationConfiguration) {
       jgen.writeStringField(typeSer.getPropertyName(), BearerTokenAuthenticationConfiguration.TYPE);
     }
+    else if (value instanceof GoogleAuthenticationConfiguration) {
+      jgen.writeStringField(typeSer.getPropertyName(), GoogleAuthenticationConfiguration.TYPE);
+    }
     else {
       // be foolproof, if new type added but this class is not updated
       throw new JsonGenerationException("Unsupported type:" + value.getClass().getName(), jgen);
@@ -98,6 +102,10 @@ public class AuthenticationConfigurationSerializer
     else if (value instanceof BearerTokenAuthenticationConfiguration) {
       BearerTokenAuthenticationConfiguration btac = (BearerTokenAuthenticationConfiguration) value;
       jgen.writeStringField(BearerTokenAuthenticationConfiguration.TYPE, passwordHelper.encrypt(btac.getBearerToken()));
+    }
+    else if (value instanceof GoogleAuthenticationConfiguration) {
+      GoogleAuthenticationConfiguration gac = (GoogleAuthenticationConfiguration)value;
+      // nothing to write really.
     }
     else {
       // be foolproof, if new type added but this class is not updated

--- a/components/nexus-httpclient/src/main/java/org/sonatype/nexus/httpclient/config/AuthenticationConfiguration.java
+++ b/components/nexus-httpclient/src/main/java/org/sonatype/nexus/httpclient/config/AuthenticationConfiguration.java
@@ -32,7 +32,8 @@ import static com.google.common.base.Preconditions.checkNotNull;
 @JsonSubTypes({
     @Type(value = BearerTokenAuthenticationConfiguration.class, name = BearerTokenAuthenticationConfiguration.TYPE),
     @Type(value = NtlmAuthenticationConfiguration.class, name = NtlmAuthenticationConfiguration.TYPE),
-    @Type(value = UsernameAuthenticationConfiguration.class, name = UsernameAuthenticationConfiguration.TYPE)
+    @Type(value = UsernameAuthenticationConfiguration.class, name = UsernameAuthenticationConfiguration.TYPE),
+    @Type(value = GoogleAuthenticationConfiguration.class, name = GoogleAuthenticationConfiguration.TYPE),    
 })
 public abstract class AuthenticationConfiguration
     implements Cloneable
@@ -44,7 +45,8 @@ public abstract class AuthenticationConfiguration
   public static final Map<String, Class<? extends AuthenticationConfiguration>> TYPES = ImmutableMap.of(
       UsernameAuthenticationConfiguration.TYPE, UsernameAuthenticationConfiguration.class,
       NtlmAuthenticationConfiguration.TYPE, NtlmAuthenticationConfiguration.class,
-      BearerTokenAuthenticationConfiguration.TYPE, BearerTokenAuthenticationConfiguration.class
+      BearerTokenAuthenticationConfiguration.TYPE, BearerTokenAuthenticationConfiguration.class,
+      GoogleAuthenticationConfiguration.TYPE, GoogleAuthenticationConfiguration.class
   );
 
   private final String type;

--- a/components/nexus-httpclient/src/main/java/org/sonatype/nexus/httpclient/config/ConfigurationCustomizer.java
+++ b/components/nexus-httpclient/src/main/java/org/sonatype/nexus/httpclient/config/ConfigurationCustomizer.java
@@ -283,6 +283,10 @@ public class ConfigurationCustomizer
       credentials = null;
       authSchemes = emptyList();
     }
+    else if (authentication instanceof GoogleAuthenticationConfiguration) {
+      credentials = null;
+      authSchemes = emptyList();
+    }
     else {
       throw new IllegalArgumentException("Unsupported authentication configuration: " + authentication);
     }

--- a/components/nexus-httpclient/src/main/java/org/sonatype/nexus/httpclient/config/GoogleAuthenticationConfiguration.java
+++ b/components/nexus-httpclient/src/main/java/org/sonatype/nexus/httpclient/config/GoogleAuthenticationConfiguration.java
@@ -1,0 +1,34 @@
+/*
+ * Sonatype Nexus (TM) Open Source Version
+ * Copyright (c) 2008-present Sonatype, Inc.
+ * All rights reserved. Includes the third-party code listed at http://links.sonatype.com/products/nexus/oss/attributions.
+ *
+ * This program and the accompanying materials are made available under the terms of the Eclipse Public License Version 1.0,
+ * which accompanies this distribution and is available at http://www.eclipse.org/legal/epl-v10.html.
+ *
+ * Sonatype Nexus (TM) Professional Version is available from Sonatype, Inc. "Sonatype" and "Sonatype Nexus" are trademarks
+ * of Sonatype, Inc. Apache Maven is a trademark of the Apache Software Foundation. M2eclipse is a trademark of the
+ * Eclipse Foundation. All other trademarks are the property of their respective owners.
+ */
+package org.sonatype.nexus.httpclient.config;
+
+/**
+ * Google authentication configuration.
+ * It's all automatic
+ *
+ * @since 3.0
+ */
+public class GoogleAuthenticationConfiguration
+  extends AuthenticationConfiguration
+{
+  public static final String TYPE = "google";
+
+  public GoogleAuthenticationConfiguration() {
+    super(TYPE);
+  }
+  @Override
+  public String toString() {
+    return getClass().getSimpleName() + "{" +
+        '}';
+  }
+}

--- a/components/nexus-repository-view/pom.xml
+++ b/components/nexus-repository-view/pom.xml
@@ -78,6 +78,10 @@
       <artifactId>objenesis</artifactId>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>com.google.auth</groupId>
+      <artifactId>google-auth-library-oauth2-http</artifactId>
+    </dependency>
   </dependencies>
 
   <build>

--- a/plugins/nexus-coreui-plugin/src/frontend/src/components/pages/admin/Repositories/facets/GenericHttpAuthConfiguration.jsx
+++ b/plugins/nexus-coreui-plugin/src/frontend/src/components/pages/admin/Repositories/facets/GenericHttpAuthConfiguration.jsx
@@ -54,6 +54,7 @@ export default function GenericHttpAuthConfiguration({parentMachine}) {
           <option value="">{EDITOR.NONE_OPTION}</option>
           <option value="username">{EDITOR.USERNAME_OPTION}</option>
           <option value="ntlm">{EDITOR.NTLM_OPTION}</option>
+          <option value="google">{EDITOR.GOOGLE_OPTION}</option>
         </NxFormSelect>
       </NxFormGroup>
 

--- a/plugins/nexus-coreui-plugin/src/frontend/src/constants/pages/admin/repository/RepositoriesStrings.jsx
+++ b/plugins/nexus-coreui-plugin/src/frontend/src/constants/pages/admin/repository/RepositoriesStrings.jsx
@@ -150,6 +150,7 @@ export default {
       NTLM_OPTION: 'Windows NTLM',
       NTLM_HOST_LABEL: 'Windows NTLM hostname',
       NTLM_DOMAIN_LABEL: 'Windows NTLM domain',
+      GOOGLE_OPTION: 'Google',
       REQUEST_SETTINGS_CAPTION: 'HTTP Request Settings',
       USER_AGENT_LABEL: 'User-Agent Customization',
       USER_AGEN_SUBLABEL: 'Define a custom fragment to append to "User-Agent" header in HTTP requests',

--- a/plugins/nexus-coreui-plugin/src/frontend/src/constants/pages/admin/system/HttpStrings.js
+++ b/plugins/nexus-coreui-plugin/src/frontend/src/constants/pages/admin/system/HttpStrings.js
@@ -49,6 +49,7 @@ export default {
         USERNAME: 'Username',
         PASSWORD: 'Password',
         HOST_NAME: 'Windows NTLM Hostname',
+        
         DOMAIN: 'Windows NTLM Domain'
       },
       EXCLUDE: {

--- a/plugins/nexus-coreui-plugin/src/main/resources/static/rapture/NX/coreui/app/PluginStrings.js
+++ b/plugins/nexus-coreui-plugin/src/main/resources/static/rapture/NX/coreui/app/PluginStrings.js
@@ -540,6 +540,7 @@ Ext.define('NX.coreui.app.PluginStrings', {
     Repository_Facet_HttpClientFacet_AuthenticationType_FieldLabel: 'Authentication type',
     Repository_Facet_HttpClientFacet_AuthenticationType_Username: 'Username',
     Repository_Facet_HttpClientFacet_AuthenticationType_NTLM: 'Windows NTLM',
+    Repository_Facet_HttpClientFacet_AuthenticationType_Google: 'Google',
     Repository_Facet_HttpClientFacet_AuthenticationType_Bearer_Token: 'Preemptive Bearer Token',
     Repository_Facet_HttpClientFacet_Authentication_Title: 'Authentication',
     Repository_Facet_HttpClientFacet_HTTP_Title: 'HTTP request settings',

--- a/plugins/nexus-coreui-plugin/src/main/resources/static/rapture/NX/coreui/view/repository/facet/HttpClientFacet.js
+++ b/plugins/nexus-coreui-plugin/src/main/resources/static/rapture/NX/coreui/view/repository/facet/HttpClientFacet.js
@@ -167,7 +167,8 @@ Ext.define('NX.coreui.view.repository.facet.HttpClientFacet', {
   getAuthTypeStore: function() {
     return [
       ['username', NX.I18n.get('Repository_Facet_HttpClientFacet_AuthenticationType_Username')],
-      ['ntlm', NX.I18n.get('Repository_Facet_HttpClientFacet_AuthenticationType_NTLM')]
+      ['ntlm', NX.I18n.get('Repository_Facet_HttpClientFacet_AuthenticationType_NTLM')],
+      ['google', NX.I18n.get('Repository_Facet_HttpClientFacet_AuthenticationType_Google')]
     ];
   }
 

--- a/pom.xml
+++ b/pom.xml
@@ -622,7 +622,6 @@
         <version>3.71.0-SNAPSHOT</version>
         <type>zip</type>
       </dependency>
-
     </dependencies>
   </dependencyManagement>
 


### PR DESCRIPTION
Google auth will use Google Application Default Credentials present in the environment to add a Bearer token to HTTP requests. This allows nexus to be configured on supported environments for Workload Identity and avoids the need for service account keys.

Fixes: https://github.com/sonatype/nexus-public/issues/420