### PR TITLE
Fixing flaky test in LogbackLoggerOverridesTest

### DIFF
--- a/components/nexus-base/src/main/java/org/sonatype/nexus/internal/log/overrides/file/LogbackLoggerOverrides.java
+++ b/components/nexus-base/src/main/java/org/sonatype/nexus/internal/log/overrides/file/LogbackLoggerOverrides.java
@@ -13,8 +13,7 @@
 package org.sonatype.nexus.internal.log.overrides.file;
 
 import java.io.File;
-import java.util.Collections;
-import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.Iterator;
 import java.util.Map;
 import java.util.Map.Entry;
@@ -45,7 +44,7 @@ public class LogbackLoggerOverrides
     extends LogbackLoggerOverridesSupport
     implements LoggerOverrides
 {
-  private final Map<String, LoggerLevel> loggerLevels = new HashMap<>();
+  private final Map<String, LoggerLevel> loggerLevels = new LinkedHashMap<>();
 
   @Inject
   public LogbackLoggerOverrides(final ApplicationDirectories applicationDirectories) {

--- a/components/nexus-base/src/test/java/org/sonatype/nexus/internal/log/overrides/file/LogbackLoggerOverridesTest.java
+++ b/components/nexus-base/src/test/java/org/sonatype/nexus/internal/log/overrides/file/LogbackLoggerOverridesTest.java
@@ -116,11 +116,11 @@ public class LogbackLoggerOverridesTest
     xml.append("<included>");
     xml.append(System.lineSeparator());
     if (!afterReset) {
-      xml.append("  <logger name='bar' level='INFO'/>");
-      xml.append(System.lineSeparator());
       xml.append("  <property name='root.level' value='WARN'/>");
       xml.append(System.lineSeparator());
       xml.append("  <logger name='foo' level='ERROR'/>");
+      xml.append(System.lineSeparator());
+      xml.append("  <logger name='bar' level='INFO'/>");
       xml.append(System.lineSeparator());
     }
     xml.append("</included>");


### PR DESCRIPTION
## Description

This change is meant to fix a flaky test - `testSave_writtenInLogbackXMLFormat()` in [`LogbackLoggerOverridesTest.java`](https://github.com/sonatype/nexus-public/blob/main/components/nexus-base/src/test/java/org/sonatype/nexus/internal/log/overrides/file/LogbackLoggerOverridesTest.java#L52)


## Analysis

This test presents flakiness because the ordering of `loggerLevels` in [LogbackLoggerOverrides.java](https://github.com/sonatype/nexus-public/blob/main/components/nexus-base/src/main/java/org/sonatype/nexus/internal/log/overrides/file/LogbackLoggerOverrides.java#L48) is non-deterministic. 

This can be reproduced by running the following command using the [nondex](https://github.com/TestingResearchIllinois/NonDex) plugin. 

`mvn -pl components/nexus-base edu.illinois:nondex-maven-plugin:2.1.7:nondex -Dtest="LogbackLoggerOverridesTest"`

throwing the error 

```
[ERROR] Failures:
[ERROR]   LogbackLoggerOverridesTest.testSave_writtenInLogbackXMLFormat:64
Expected: is "<?xml version='1.0' encoding='UTF-8'?>\r\n\r\n<!--\r\nDO NOT EDIT - Automatically generated; User-customized logging levels\r\n-->\r\n\r\n<included>\r\n  <logger name='bar' level='INFO'/>\r\n  <property name='root.level' value='WARN'/>\r\n  <logger name='foo' level='ERROR'/>\r\n</included>\r\n"
     but: was "<?xml version='1.0' encoding='UTF-8'?>\r\n\r\n<!--\r\nDO NOT EDIT - Automatically generated; User-customized logging levels\r\n-->\r\n\r\n<included>\r\n  <property name='root.level' value='WARN'/>\r\n  <logger name='bar' level='INFO'/>\r\n  <logger name='foo' level='ERROR'/>\r\n</included>\r\n"
```

Since the above test is converting these into XMLs and comparing them as Strings, it is failing. Since the order of elements in an XML matters, converting these Strings into XMLs will not fix the test.

## Fix
In order to make the ordering of `loggerLevels` deterministic, this fix is converting it's type from `HashMap.java` to `LinkedHashMap.java`, which retains insertion order. Furthermore this fix also changes the ordering of loglevels in  [getExpectedXml(boolean afterReset)](https://github.com/sonatype/nexus-public/blob/main/components/nexus-base/src/test/java/org/sonatype/nexus/internal/log/overrides/file/LogbackLoggerOverridesTest.java#L104) in order to maintain a consistent loggerLevel ordering with the tests in the class.

I would love to get feedback on this Pull Request. Do let me know if you'd like to see any more changes!

Thanks

