### PR TITLE
feat: support for authType=bearerToken for NPM proxy repository 

### DIFF
--- a/components/nexus-repository-services/src/main/java/org/sonatype/nexus/repository/rest/api/ProxyRepositoryApiRequestToConfigurationConverter.java
+++ b/components/nexus-repository-services/src/main/java/org/sonatype/nexus/repository/rest/api/ProxyRepositoryApiRequestToConfigurationConverter.java
@@ -90,6 +90,7 @@ public class ProxyRepositoryApiRequestToConfigurationConverter<T extends ProxyRe
       authenticationConfiguration.set("password", authentication.getPassword());
       authenticationConfiguration.set("ntlmHost", authentication.getNtlmHost());
       authenticationConfiguration.set("ntlmDomain", authentication.getNtlmDomain());
+      authenticationConfiguration.set("bearerToken", authentication.getBearerToken());
     }
   }
 

--- a/components/nexus-repository-services/src/main/java/org/sonatype/nexus/repository/rest/api/SimpleApiRepositoryAdapter.java
+++ b/components/nexus-repository-services/src/main/java/org/sonatype/nexus/repository/rest/api/SimpleApiRepositoryAdapter.java
@@ -206,8 +206,9 @@ public class SimpleApiRepositoryAdapter
       String username = authenticationMap.get("username", String.class);
       String ntlmHost = authenticationMap.get("ntlmHost", String.class);
       String ntlmDomain = authenticationMap.get("ntlmDomain", String.class);
+      String bearerToken = authenticationMap.get("bearerToken", String.class);
 
-      authentication = new HttpClientConnectionAuthenticationAttributes(type, username, null, ntlmHost, ntlmDomain);
+      authentication = new HttpClientConnectionAuthenticationAttributes(type, username, null, ntlmHost, ntlmDomain, bearerToken);
     }
 
     HttpClientConnectionAttributes connection = null;

--- a/components/nexus-repository-services/src/main/java/org/sonatype/nexus/repository/rest/api/model/HttpClientConnectionAuthenticationAttributes.java
+++ b/components/nexus-repository-services/src/main/java/org/sonatype/nexus/repository/rest/api/model/HttpClientConnectionAuthenticationAttributes.java
@@ -35,11 +35,24 @@ public class HttpClientConnectionAuthenticationAttributes
   @ApiModelProperty(access = "writeOnly")
   protected final String password;
 
+  @ApiModelProperty(access = "writeOnly")
+  protected final String bearerToken;
+
   @ApiModelProperty
   protected final String ntlmHost;
 
   @ApiModelProperty
   protected final String ntlmDomain;
+
+  public HttpClientConnectionAuthenticationAttributes(
+          @JsonProperty("type") final String type,
+          @JsonProperty("username") final String username,
+          @JsonProperty(value = "password", access = Access.WRITE_ONLY) final String password,
+          @JsonProperty("ntlmHost") final String ntlmHost,
+          @JsonProperty("ntlmDomain") final String ntlmDomain)
+  {
+    this(type, username, password, ntlmHost, ntlmDomain, null);
+  }
 
   @JsonCreator
   public HttpClientConnectionAuthenticationAttributes(
@@ -47,13 +60,15 @@ public class HttpClientConnectionAuthenticationAttributes
       @JsonProperty("username") final String username,
       @JsonProperty(value = "password", access = Access.WRITE_ONLY) final String password,
       @JsonProperty("ntlmHost") final String ntlmHost,
-      @JsonProperty("ntlmDomain") final String ntlmDomain)
+      @JsonProperty("ntlmDomain") final String ntlmDomain,
+      @JsonProperty(value = "bearerToken", access = Access.WRITE_ONLY) final String bearerToken)
   {
     this.type = type;
     this.username = username;
     this.password = password;
     this.ntlmHost = ntlmHost;
     this.ntlmDomain = ntlmDomain;
+    this.bearerToken = bearerToken;
   }
 
   public String getType() {
@@ -74,5 +89,9 @@ public class HttpClientConnectionAuthenticationAttributes
 
   public String getNtlmDomain() {
     return ntlmDomain;
+  }
+
+  public String getBearerToken() {
+    return bearerToken;
   }
 }

--- a/plugins/nexus-repository-maven/src/main/java/org/sonatype/nexus/repository/maven/rest/HttpClientConnectionAuthenticationAttributesWithPreemptive.java
+++ b/plugins/nexus-repository-maven/src/main/java/org/sonatype/nexus/repository/maven/rest/HttpClientConnectionAuthenticationAttributesWithPreemptive.java
@@ -39,9 +39,10 @@ public class HttpClientConnectionAuthenticationAttributesWithPreemptive
       @JsonProperty("username") final String username,
       @JsonProperty(value = "password", access = Access.WRITE_ONLY) final String password,
       @JsonProperty("ntlmHost") final String ntlmHost,
-      @JsonProperty("ntlmDomain") final String ntlmDomain)
+      @JsonProperty("ntlmDomain") final String ntlmDomain,
+      @JsonProperty(value = "bearerToken", access = Access.WRITE_ONLY) final String bearerToken)
   {
-    super(type, username, password, ntlmHost, ntlmDomain);
+    super(type, username, password, ntlmHost, ntlmDomain, bearerToken);
     this.preemptive = preemptive;
   }
 
@@ -49,7 +50,7 @@ public class HttpClientConnectionAuthenticationAttributesWithPreemptive
       final HttpClientConnectionAuthenticationAttributes auth,
       final Boolean preemptive)
   {
-    super(auth.getType(), auth.getUsername(), auth.getPassword(), auth.getNtlmHost(), auth.getNtlmDomain());
+    super(auth.getType(), auth.getUsername(), auth.getPassword(), auth.getNtlmHost(), auth.getNtlmDomain(), auth.getBearerToken());
     this.preemptive = preemptive;
   }
 


### PR DESCRIPTION
This MR adds support for the authType `bearerToken` for an NPM proxy repository (GH-540)