### PR TITLE
Fix (deps): QOS.CH logback-core Expression Language Injection vulnerability

### DIFF
--- a/buildsupport/logging/pom.xml
+++ b/buildsupport/logging/pom.xml
@@ -29,7 +29,7 @@
 
   <properties>
     <slf4j.version>1.7.36</slf4j.version>
-    <logback.version>1.2.13</logback.version>
+    <logback.version>1.3.15</logback.version>
     <pax-logging.version>2.1.3</pax-logging.version>
   </properties>
 


### PR DESCRIPTION
ACE vulnerability in JaninoEventEvaluator by QOS.CH logback-core up to and including version 1.5.12 in Java applications allows attackers to execute arbitrary code by compromising an existing logback configuration file or by injecting an environment variable before program execution. Malicious logback configuration files can allow the attacker to execute arbitrary code using the JaninoEventEvaluator extension.

A successful attack requires the user to have write access to a configuration file. Alternatively, the attacker could inject a malicious environment variable pointing to a malicious configuration file. In both cases, the attack requires existing privilege.

CVE-2024-12798
[CWE-917](https://cwe.mitre.org/data/definitions/917.html)