### PR TITLE
apt: relative path for property Filename in Packages (fixes: #586)

### DIFF
--- a/plugins/nexus-repository-apt/src/main/java/org/sonatype/nexus/repository/apt/datastore/internal/AptContentFacetImpl.java
+++ b/plugins/nexus-repository-apt/src/main/java/org/sonatype/nexus/repository/apt/datastore/internal/AptContentFacetImpl.java
@@ -14,6 +14,7 @@ package org.sonatype.nexus.repository.apt.datastore.internal;
 
 import java.io.IOException;
 import java.io.InputStream;
+import java.nio.file.Paths;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
@@ -197,7 +198,7 @@ public class AptContentFacetImpl
 
     return controlFile.getParagraphs().get(0)
         .withFields(Arrays.asList(
-            new ControlFile.ControlField("Filename", asset.path()),
+            new ControlFile.ControlField("Filename", Paths.get("/").relativize(Paths.get(asset.path())).toString()),
             new ControlFile.ControlField("Size", Long.toString(assetBlob.blobSize())),
             new ControlFile.ControlField("MD5Sum", checksums.get(MD5.name())),
             new ControlFile.ControlField("SHA1", checksums.get(SHA1.name())),


### PR DESCRIPTION
As described in #586 
> The Nexus Repo generated Packages file does not follow the DebianRepository spec in regard to the Filename:  field.
> 
> The Filename:  field that Nexus Repo generates contains a leading /, this is in direct violation of the spec which requires it to be a relative path ([source](https://wiki.debian.org/DebianRepository/Format#Filename)). The UNIX spec defines a relative path as a path without a leading slash ([source](https://pubs.opengroup.org/onlinepubs/9699919799/basedefs/V1_chap03.html#tag_03_324)).

This creates issues with many apt mirroring utilities.

Uses `Paths.relativize()` with base `/` to always output a relative path.

Review advised, unable to test and build due to https://github.com/sonatype/nexus-public/issues/600 