### PR TITLE
Fix DataStoreRestorer arbitrary file access during archive extraction zipslip

### DIFF
--- a/components/nexus-datastore/src/main/java/org/sonatype/nexus/datastore/internal/DataStoreRestorerLocalImpl.java
+++ b/components/nexus-datastore/src/main/java/org/sonatype/nexus/datastore/internal/DataStoreRestorerLocalImpl.java
@@ -99,7 +99,11 @@ public class DataStoreRestorerLocalImpl
     try (ZipFile zip = new ZipFile(backupArchive)) {
       return zip.stream().filter(entry -> entry.getName().equals(dataStoreFileName)).findFirst().map(entry -> {
         try {
-          Files.copy(zip.getInputStream(entry), dbDirectory.resolve(entry.getName()));
+          Path targetPath = dbDirectory.resolve(entry.getName()).normalize();
+          if (!targetPath.startsWith(dbDirectory.normalize())) {
+            throw new IOException("Entry is outside of the target dir: " + entry.getName());
+          }
+          Files.copy(zip.getInputStream(entry), targetPath);
           log.info("Restored {}", entry.getName());
           return true;
         }


### PR DESCRIPTION
https://github.com/sonatype/nexus-public/blob/aec50e47d080933bc235f29e2669591343112a12/components/nexus-datastore/src/main/java/org/sonatype/nexus/datastore/internal/DataStoreRestorerLocalImpl.java#L102-L102

Fix the "Zip Slip" vulnerability, we must ensure that the file path constructed from the zip entry name does not escape the intended destination directory. This is best achieved by resolving the entry name against the destination directory, normalizing the resulting path, and then checking that the normalized path starts with the normalized destination directory path. If the check fails, we should throw an exception or skip the entry. The fix should be applied in the `restore` method, specifically before calling `Files.copy`. We will use `Path.normalize()` and `Path.startsWith()` for this purpose. No new methods or imports are needed, as the required classes are already imported.


**References**
[Zip Slip Vulnerability](https://snyk.io/research/zip-slip-vulnerability)
[Path Traversal](https://owasp.org/www-community/attacks/Path_Traversal)
[CWE-22](https://cwe.mitre.org/data/definitions/22.html)