### PR TITLE
Skip metadata validation when layout policy is permissive (issue #917)

### DIFF
--- a/public/common/components/formats/nexus-repository-maven/src/main/java/org/sonatype/nexus/content/maven/internal/recipe/MavenContentFacetImpl.java
+++ b/public/common/components/formats/nexus-repository-maven/src/main/java/org/sonatype/nexus/content/maven/internal/recipe/MavenContentFacetImpl.java
@@ -247,7 +247,9 @@ public class MavenContentFacetImpl
   }
 
   private boolean isMetadataAndValidationEnabled(final MavenPath mavenPath) {
-    return mavenPath.getFileName().equals(METADATA_FILENAME) && metadataValidationEnabled;
+    return mavenPath.getFileName().equals(METADATA_FILENAME)
+        && metadataValidationEnabled
+        && config.layoutPolicy != LayoutPolicy.PERMISSIVE;
   }
 
   private void validate(final MavenPath mavenPath, final TempBlob blob) {


### PR DESCRIPTION
Closes #917

When Layout Policy is set to Permissive, skip MavenMetadataContentValidator path validation.