### PR TITLE
apt: add distribution and component upload metadata

### DIFF
--- a/public/common/components/formats/nexus-repository-apt/src/main/java/org/sonatype/nexus/repository/apt/AptUploadHandlerSupport.java
+++ b/public/common/components/formats/nexus-repository-apt/src/main/java/org/sonatype/nexus/repository/apt/AptUploadHandlerSupport.java
@@ -14,13 +14,22 @@ package org.sonatype.nexus.repository.apt;
 
 import java.util.Collections;
 import java.util.Set;
+import java.util.Arrays;
 
 import org.sonatype.nexus.repository.Repository;
 import org.sonatype.nexus.repository.rest.UploadDefinitionExtension;
 import org.sonatype.nexus.repository.security.ContentPermissionChecker;
 import org.sonatype.nexus.repository.security.VariableResolverAdapter;
 import org.sonatype.nexus.repository.upload.UploadDefinition;
+import org.sonatype.nexus.repository.upload.UploadFieldDefinition;
+import org.sonatype.nexus.repository.upload.UploadFieldDefinition.Type;
 import org.sonatype.nexus.repository.upload.UploadHandlerSupport;
+
+
+import static org.sonatype.nexus.repository.apt.internal.AptProperties.P_DISTRIBUTION;
+import static org.sonatype.nexus.repository.apt.internal.AptProperties.P_DISTRIBUTION_HELP_TEXT;
+import static org.sonatype.nexus.repository.apt.internal.AptProperties.P_COMPONENT;
+import static org.sonatype.nexus.repository.apt.internal.AptProperties.P_COMPONENT_HELP_TEXT;
 
 /**
  * Common base for an Apt upload handlers
@@ -53,7 +62,12 @@ public abstract class AptUploadHandlerSupport
   @Override
   public UploadDefinition getDefinition() {
     if (definition == null) {
-      definition = getDefinition(AptFormat.NAME, false);
+      definition = getDefinition(AptFormat.NAME, false,
+          Arrays.asList(),
+          Arrays.asList(new UploadFieldDefinition(P_DISTRIBUTION, P_DISTRIBUTION_HELP_TEXT, true, Type.STRING), 
+          new UploadFieldDefinition(P_COMPONENT, P_COMPONENT_HELP_TEXT, true, Type.STRING)),
+          null
+      );
     }
     return definition;
   }

--- a/public/common/components/formats/nexus-repository-apt/src/main/java/org/sonatype/nexus/repository/apt/api/AptHostedRepositoriesAttributes.java
+++ b/public/common/components/formats/nexus-repository-apt/src/main/java/org/sonatype/nexus/repository/apt/api/AptHostedRepositoriesAttributes.java
@@ -24,8 +24,7 @@ import javax.validation.constraints.NotEmpty;
  */
 public class AptHostedRepositoriesAttributes
 {
-  @ApiModelProperty(value = "Distribution to fetch", example = "bionic")
-  @NotEmpty
+  @ApiModelProperty(value = "Default Distribution Codename", example = "trixie")
   protected final String distribution;
 
   @JsonCreator

--- a/public/common/components/formats/nexus-repository-apt/src/main/java/org/sonatype/nexus/repository/apt/datastore/AptUploadHandler.java
+++ b/public/common/components/formats/nexus-repository-apt/src/main/java/org/sonatype/nexus/repository/apt/datastore/AptUploadHandler.java
@@ -46,8 +46,10 @@ import org.sonatype.nexus.repository.view.payloads.TempBlobPayload;
 import org.springframework.beans.factory.annotation.Qualifier;
 
 import static org.apache.commons.lang3.StringUtils.prependIfMissing;
+import static org.sonatype.nexus.repository.apt.internal.AptProperties.P_COMPONENT;
+import static org.sonatype.nexus.repository.apt.internal.AptProperties.P_DISTRIBUTION;
+
 import org.springframework.stereotype.Component;
-import org.springframework.beans.factory.annotation.Qualifier;
 
 /**
  * Support for uploading an Apt components via UI
@@ -73,15 +75,18 @@ public class AptUploadHandler
   public UploadResponse handle(final Repository repository, final ComponentUpload upload) throws IOException {
     AptContentFacet aptContentFacet = repository.facet(AptContentFacet.class);
     AptHostedFacet hostedFacet = repository.facet(AptHostedFacet.class);
+    String component = upload.getAssetUploads().get(0).getField(P_COMPONENT);
+    String distribution = upload.getAssetUploads().get(0).getField(P_DISTRIBUTION);
     PartPayload payload = upload.getAssetUploads().get(0).getPayload();
     try (TempBlob tempBlob = aptContentFacet.getTempBlob(payload)) {
-      ControlFile controlFile = AptPackageParser
-          .parsePackageInfo(tempBlob)
-          .getControlFile();
-      String assetPath = AptFacetHelper.buildAssetPath(controlFile);
+      PackageInfo packageInfo = AptPackageParser
+          .parsePackageInfo(tempBlob);
+      packageInfo.setComponent(component);
+      packageInfo.setDistribution(distribution);
+      String assetPath = AptFacetHelper.buildAssetPath(packageInfo);
       doValidation(repository, prependIfMissing(assetPath, "/"));
       Content content = hostedFacet
-          .put(assetPath, payload, new PackageInfo(controlFile))
+          .put(assetPath, payload, packageInfo)
           .markAsCached(payload)
           .download();
       return new UploadResponse(Collections.singletonList(content), Collections.singletonList(assetPath));
@@ -102,13 +107,12 @@ public class AptUploadHandler
 
     Payload payload = new PathPayload(file.toPath(), Files.probeContentType(file.toPath()));
     try (TempBlob tempBlob = aptContentFacet.getTempBlob(payload)) {
-      ControlFile controlFile = AptPackageParser
-          .parsePackageInfo(tempBlob)
-          .getControlFile();
-      String assetPath = AptFacetHelper.buildAssetPath(controlFile);
+      PackageInfo packageInfo = AptPackageParser
+          .parsePackageInfo(tempBlob);
+      String assetPath = AptFacetHelper.buildAssetPath(packageInfo);
       doValidation(repository, prependIfMissing(assetPath, "/"));
       return hostedFacet
-          .put(assetPath, payload, new PackageInfo(controlFile))
+          .put(assetPath, payload, packageInfo)
           .markAsCached(payload)
           .download();
     }
@@ -121,14 +125,13 @@ public class AptUploadHandler
     AptHostedFacet hostedFacet = repository.facet(AptHostedFacet.class);
 
     try (TempBlob tempBlob = aptContentFacet.getTempBlob(configuration.getInputStream(), null)) {
-      ControlFile controlFile = AptPackageParser
-          .parsePackageInfo(tempBlob)
-          .getControlFile();
-      String assetPath = AptFacetHelper.buildAssetPath(controlFile);
+      PackageInfo packageInfo = AptPackageParser
+          .parsePackageInfo(tempBlob);
+      String assetPath = AptFacetHelper.buildAssetPath(packageInfo);
       doValidation(repository, prependIfMissing(assetPath, "/"));
       Payload payload = new TempBlobPayload(tempBlob, null);
       return hostedFacet
-          .put(assetPath, payload, new PackageInfo(controlFile))
+          .put(assetPath, payload, packageInfo)
           .markAsCached(payload)
           .download();
     }

--- a/public/common/components/formats/nexus-repository-apt/src/main/java/org/sonatype/nexus/repository/apt/datastore/internal/AptContentFacetImpl.java
+++ b/public/common/components/formats/nexus-repository-apt/src/main/java/org/sonatype/nexus/repository/apt/datastore/internal/AptContentFacetImpl.java
@@ -66,6 +66,8 @@ import static org.sonatype.nexus.repository.apt.debian.Utils.isDebPackageContent
 import static org.sonatype.nexus.repository.apt.internal.AptFacetHelper.normalizeAssetPath;
 import static org.sonatype.nexus.repository.apt.internal.AptProperties.DEB;
 import static org.sonatype.nexus.repository.apt.internal.AptProperties.P_ARCHITECTURE;
+import static org.sonatype.nexus.repository.apt.internal.AptProperties.P_COMPONENT;
+import static org.sonatype.nexus.repository.apt.internal.AptProperties.P_DISTRIBUTION;
 import static org.sonatype.nexus.repository.apt.internal.AptProperties.P_INDEX_SECTION;
 import static org.sonatype.nexus.repository.apt.internal.AptProperties.P_PACKAGE_NAME;
 import static org.sonatype.nexus.repository.apt.internal.AptProperties.P_PACKAGE_VERSION;
@@ -194,6 +196,12 @@ public class AptContentFacetImpl
     formatAttributes.put(P_ARCHITECTURE, info.getArchitecture());
     formatAttributes.put(P_PACKAGE_NAME, info.getPackageName());
     formatAttributes.put(P_PACKAGE_VERSION, info.getVersion());
+    if(info.getDistribution()!=null) {
+      formatAttributes.put(P_DISTRIBUTION, info.getDistribution());
+    }
+    if(info.getComponent()!=null) {
+      formatAttributes.put(P_COMPONENT, info.getComponent());
+    }
     formatAttributes.put(P_INDEX_SECTION, buildIndexSection(controlFile, asset));
 
     FormatAttributesUtils.setFormatAttributes(asset, formatAttributes);

--- a/public/common/components/formats/nexus-repository-apt/src/main/java/org/sonatype/nexus/repository/apt/datastore/internal/hosted/AptHostedHandler.java
+++ b/public/common/components/formats/nexus-repository-apt/src/main/java/org/sonatype/nexus/repository/apt/datastore/internal/hosted/AptHostedHandler.java
@@ -23,7 +23,6 @@ import org.sonatype.nexus.repository.apt.datastore.AptContentFacet;
 import org.sonatype.nexus.repository.apt.datastore.internal.hosted.metadata.AptMetadataRebuildSchedulerFacet;
 import org.sonatype.nexus.repository.apt.internal.AptFacetHelper;
 import org.sonatype.nexus.repository.apt.internal.AptPackageParser;
-import org.sonatype.nexus.repository.apt.internal.debian.ControlFile;
 import org.sonatype.nexus.repository.apt.internal.debian.PackageInfo;
 import org.sonatype.nexus.repository.apt.internal.snapshot.AptSnapshotHandler;
 import org.sonatype.nexus.repository.http.HttpResponses;
@@ -42,6 +41,9 @@ import static org.sonatype.nexus.repository.http.HttpMethods.GET;
 import static org.sonatype.nexus.repository.http.HttpMethods.HEAD;
 import static org.sonatype.nexus.repository.http.HttpMethods.POST;
 import org.springframework.stereotype.Component;
+
+import static org.sonatype.nexus.repository.apt.internal.AptProperties.P_DISTRIBUTION;
+import static org.sonatype.nexus.repository.apt.internal.AptProperties.P_COMPONENT;
 
 /**
  * Apt handlers
@@ -92,16 +94,19 @@ public class AptHostedHandler
     }
     else if (StringUtils.isBlank(path)) {
       final Payload payload = context.getRequest().getPayload();
+      final String distribution = context.getRequest().getParameters().get(P_DISTRIBUTION);
+      final String component = context.getRequest().getParameters().get(P_COMPONENT);
       try (TempBlob tempBlob = contentFacet.getTempBlob(payload)) {
-        ControlFile controlFile = AptPackageParser
-            .parsePackageInfo(tempBlob)
-            .getControlFile();
-        String assetPath = AptFacetHelper.buildAssetPath(controlFile);
+        PackageInfo packageInfo = AptPackageParser
+            .parsePackageInfo(tempBlob);
+        packageInfo.setDistribution(distribution);
+        packageInfo.setComponent(component);
+        String assetPath = AptFacetHelper.buildAssetPath(packageInfo);
         long payloadSize = payload.getSize();
         String contentType = payload.getContentType();
 
         hostedFacet.put(assetPath, new StreamPayload(tempBlob, payloadSize, contentType),
-            new PackageInfo(controlFile));
+            packageInfo);
       }
       return HttpResponses.created();
     }

--- a/public/common/components/formats/nexus-repository-apt/src/main/java/org/sonatype/nexus/repository/apt/datastore/internal/hosted/metadata/AptHostedMetadataFacet.java
+++ b/public/common/components/formats/nexus-repository-apt/src/main/java/org/sonatype/nexus/repository/apt/datastore/internal/hosted/metadata/AptHostedMetadataFacet.java
@@ -21,13 +21,18 @@ import java.util.Arrays;
 import java.util.Collection;
 import java.util.Date;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Map.Entry;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.OptionalInt;
 import java.util.Set;
 import java.util.TimeZone;
+import java.util.function.Function;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 
 import jakarta.inject.Inject;
@@ -49,6 +54,8 @@ import org.sonatype.nexus.repository.apt.internal.debian.ControlFile;
 import org.sonatype.nexus.repository.apt.internal.debian.ControlFile.Paragraph;
 import org.sonatype.nexus.repository.apt.internal.gpg.AptSigningFacet;
 import org.sonatype.nexus.repository.apt.internal.hosted.CompressingTempFileStore;
+import org.sonatype.nexus.repository.apt.internal.hosted.CompressingTempFileStore.DistComponentArchKey;
+import org.sonatype.nexus.repository.apt.internal.hosted.CompressingTempFileStore.FileMetadata;
 import org.sonatype.nexus.repository.config.Configuration;
 import org.sonatype.nexus.repository.content.Asset;
 import org.sonatype.nexus.repository.content.AssetBlob;
@@ -81,6 +88,8 @@ import static org.sonatype.nexus.repository.apt.internal.AptProperties.GZ;
 import static org.sonatype.nexus.repository.apt.internal.AptProperties.P_ARCHITECTURE;
 import static org.sonatype.nexus.repository.apt.internal.AptProperties.P_INDEX_SECTION;
 import static org.sonatype.nexus.repository.apt.internal.AptProperties.P_PACKAGE_NAME;
+import static org.sonatype.nexus.repository.apt.internal.AptProperties.P_DISTRIBUTION;
+import static org.sonatype.nexus.repository.apt.internal.AptProperties.P_COMPONENT;
 import static org.sonatype.nexus.repository.apt.internal.ReleaseName.INRELEASE;
 import static org.sonatype.nexus.repository.apt.internal.ReleaseName.RELEASE;
 import static org.sonatype.nexus.repository.apt.internal.ReleaseName.RELEASE_GPG;
@@ -164,34 +173,53 @@ public class AptHostedMetadataFacet
     AptContentFacet aptFacet = content();
     AptSigningFacet signingFacet = signing();
 
-    StringBuilder sha256Builder = new StringBuilder();
-    StringBuilder md5Builder = new StringBuilder();
     String releaseFile = null;
-    Set<String> currentArchitectures = null;
-    try (CompressingTempFileStore store = buildPackageIndexes()) {
-      for (Map.Entry<String, CompressingTempFileStore.FileMetadata> entry : store.getFiles().entrySet()) {
-        storePackageIndexFiles(aptFacet, entry.getKey(), entry.getValue(), md5Builder, sha256Builder);
-      }
-      if (!store.getFiles().isEmpty()) {
-        currentArchitectures = store.getFiles().keySet();
-        releaseFile = buildReleaseFile(
-            aptFacet.getDistribution(),
-            currentArchitectures,
-            md5Builder.toString(),
-            sha256Builder.toString());
-      }
-      else {
-        // No packages in repository - remove all metadata
-        log.info("No packages found in repository: {} - removing all metadata", getRepository().getName());
-        removeAllMetadata();
+    FluentAsset releaseFileAsset = null;
+    try (CompressingTempFileStore store = buildPackageIndexes(aptFacet)) {
+
+      // Loop on each discovered distributions, components & architectures.
+      Map<String, Map<String, Map<String, FileMetadata>>> pkgIndexes = store.getFiles();
+      for (Entry<String, Map<String, Map<String, FileMetadata>>> distEntry : pkgIndexes.entrySet()) {
+        final String distribution = distEntry.getKey();
+        Set<String> currentArchitectures = new HashSet<>();
+
+        // Create package index per architecture.
+        StringBuilder sha256Builder = new StringBuilder();
+        StringBuilder md5Builder = new StringBuilder();
+        for (Entry<String, Map<String, FileMetadata>> componentEntry : distEntry.getValue().entrySet()) {
+
+          String component = componentEntry.getKey();
+          for (Entry<String, FileMetadata> archEntry : componentEntry.getValue().entrySet()) {
+            storePackageIndexFiles(aptFacet, distribution, component, archEntry.getKey(), archEntry.getValue(), md5Builder, sha256Builder);
+          }
+
+          // Collect valid architectures
+          currentArchitectures.addAll(componentEntry.getValue().keySet());
+          
+          // Clean up stale architecture metadata after successful rebuild
+          removeStaleArchitectureMetadata(distribution, component, componentEntry.getValue().keySet());
+          
+        }
+        
+        Set<String> currentComponents = distEntry.getValue().keySet();
+        if (!currentArchitectures.isEmpty()) {
+          releaseFile = buildReleaseFile(
+              distribution,
+              currentComponents,
+              currentArchitectures,
+              md5Builder.toString(),
+              sha256Builder.toString());
+          releaseFileAsset = generateReleaseFiles(distribution, releaseFile, aptFacet, signingFacet);
+        } 
+
+        // If the store is empty, then delete all metadata
+        removeStaleComponentMetadata(distribution, currentComponents);
+
       }
 
-    }
-    FluentAsset releaseFileAsset = generateReleaseFiles(releaseFile, aptFacet, signingFacet);
+      // If the store is empty, then delete all metadata
+      removeStaleDistributionMetadata(pkgIndexes.keySet());
 
-    // Clean up stale architecture metadata after successful rebuild
-    if (currentArchitectures != null && !currentArchitectures.isEmpty()) {
-      removeStaleArchitectureMetadata(currentArchitectures);
     }
 
     OffsetDateTime finishTime = clock.clusterTime();
@@ -201,6 +229,7 @@ public class AptHostedMetadataFacet
   }
 
   private FluentAsset generateReleaseFiles(
+      final String dist,
       final String releaseFile,
       final AptContentFacet aptFacet,
       final AptSigningFacet signingFacet) throws IOException
@@ -208,23 +237,23 @@ public class AptHostedMetadataFacet
     FluentAsset releaseFileAsset = null;
     if (releaseFile != null) {
       releaseFileAsset = aptFacet.put(
-          releaseIndexName(RELEASE),
+          releaseIndexName(dist, RELEASE),
           new BytesPayload(releaseFile.getBytes(StandardCharsets.UTF_8), AptMimeTypes.TEXT));
 
       aptFacet.put(
-          releaseIndexName(INRELEASE),
+          releaseIndexName(dist, INRELEASE),
           new BytesPayload(signingFacet.signInline(releaseFile), AptMimeTypes.TEXT));
 
       aptFacet.put(
-          releaseIndexName(RELEASE_GPG),
+          releaseIndexName(dist, RELEASE_GPG),
           new BytesPayload(signingFacet.signExternal(releaseFile), AptMimeTypes.SIGNATURE));
     }
     return releaseFileAsset;
   }
 
-  private CompressingTempFileStore buildPackageIndexes() throws IOException {
+  private CompressingTempFileStore buildPackageIndexes(AptContentFacet aptFacet) throws IOException {
     CompressingTempFileStore result = new CompressingTempFileStore();
-    Map<String, Writer> writersByArch = new HashMap<>();
+    Map<DistComponentArchKey, Writer> writersMap = new HashMap<>();
     boolean ok = false;
     try {
       final List<Map<String, Object>> allPackagesMetadata = data()
@@ -234,44 +263,48 @@ public class AptHostedMetadataFacet
 
       // Single-pass deduplication and grouping by architecture
       // Deduplicate by (architecture, package name) to handle KV store duplicate entries
-      Map<String, Map<String, Map<String, Object>>> packagesByArchAndName = new HashMap<>();
+      Map<DistComponentArchKey, Set<String>> packageNameSeen = new HashMap<>();
       for (Map<String, Object> pkg : allPackagesMetadata) {
+        Object distributionObj = pkg.get(P_DISTRIBUTION);
+        Object componentObj = pkg.get(P_COMPONENT);
         Object architectureObj = pkg.get(P_ARCHITECTURE);
         Object packageNameObj = pkg.get(P_PACKAGE_NAME);
         if (architectureObj == null || packageNameObj == null) {
           log.warn("Skipping package with missing architecture or name: {}", pkg);
           continue;
         }
-        String architecture = architectureObj.toString();
-        String packageName = packageNameObj.toString();
-        packagesByArchAndName
-            .computeIfAbsent(architecture, k -> new HashMap<>())
-            .put(packageName, pkg);
-      }
 
-      int totalUniquePackages = packagesByArchAndName.values()
-          .stream()
-          .mapToInt(Map::size)
-          .sum();
-      log.debug("Building package indexes: {} architectures, {} unique packages from {} KV entries",
-          packagesByArchAndName.size(), totalUniquePackages, allPackagesMetadata.size());
+        // Handle package in multiple distro
+        String distributions = distributionObj !=null ? distributionObj.toString() : aptFacet.getDistribution();
+        for(String distribution : distributions.split(",")) {
+          distribution = distribution.trim();
 
-      // Write package indexes for each architecture
-      for (Map.Entry<String, Map<String, Map<String, Object>>> archEntry : packagesByArchAndName.entrySet()) {
-        String architecture = archEntry.getKey();
-        Map<String, Map<String, Object>> packagesForArch = archEntry.getValue();
-        Writer outWriter = writersByArch.computeIfAbsent(architecture, result::openOutput);
+          // When component is not defined, default to "main" for backward compatibility
+          String component = componentObj !=null ? componentObj.toString() : "main";
+          String architecture = architectureObj.toString();
+          String packageName = packageNameObj.toString();
 
-        for (Map<String, Object> pkg : packagesForArch.values()) {
+          // Check if duplicate
+          DistComponentArchKey key = new DistComponentArchKey(distribution, component, architecture);
+          if(packageNameSeen.computeIfAbsent(key, k -> new HashSet<>()).contains(packageName)){
+            log.warn("Skipping duplicate package name: {}", pkg);
+            continue;
+          }
+          packageNameSeen.get(key).add(packageName);
+
+          // Write package details to Package Indexes
+          Writer outWriter = writersMap.computeIfAbsent(key, result::openOutput);
           final String indexSection = (String) pkg.get(P_INDEX_SECTION);
           outWriter.write(indexSection);
           outWriter.write("\n\n");
         }
+
       }
+
       ok = true;
     }
     finally {
-      for (Writer writer : writersByArch.values()) {
+      for (Writer writer : writersMap.values()) {
         IOUtils.closeQuietly(writer, null);
       }
 
@@ -283,77 +316,79 @@ public class AptHostedMetadataFacet
   }
 
   /**
-   * Removes all metadata files (Packages indexes and Release files).
-   * This is called before rebuilding to ensure stale architectures are cleaned up.
-   */
-  private void removeAllMetadata() {
-    log.debug("Removing all metadata files for repository: {}", getRepository().getName());
-    AptContentFacet aptFacet = content();
-
-    // Remove all Package index files (binary-*/Packages*)
-    try {
-      aptFacet.deleteAssetsByPrefix(normalizeAssetPath(mainBinaryPrefix()));
-    }
-    catch (Exception e) {
-      log.warn("Failed to delete package index files", e);
-    }
-
-    // Remove Release files
-    String dist = aptFacet.getDistribution();
-    deleteReleaseFile(aptFacet, dist, RELEASE);
-    deleteReleaseFile(aptFacet, dist, INRELEASE);
-    deleteReleaseFile(aptFacet, dist, RELEASE_GPG);
-  }
-
-  private void deleteReleaseFile(final AptContentFacet aptFacet, final String dist, final String fileName) {
-    try {
-      aptFacet.assets()
-          .path(normalizeAssetPath("dists/" + dist + "/" + fileName))
-          .find()
-          .ifPresent(FluentAsset::delete);
-    }
-    catch (Exception e) {
-      log.warn("Failed to delete release file: {}", fileName, e);
-    }
-  }
-
-  /**
-   * Extracts the architecture from a Package index asset path.
-   * Path format: /dists/{distribution}/main/binary-{arch}/Packages{extension}
-   *
-   * @param path the asset path
-   * @param distribution the distribution name
-   * @return the architecture or null if path doesn't match expected format
-   */
-  private String extractArchitectureFromPath(final String path, final String distribution) {
-    String pattern = "/dists/" + distribution + "/main/binary-";
-    if (path.startsWith(pattern)) {
-      String remainder = path.substring(pattern.length());
-      int slashIndex = remainder.indexOf('/');
-      if (slashIndex > 0) {
-        return remainder.substring(0, slashIndex);
-      }
-    }
-    return null;
-  }
-
-  /**
    * Removes Package index metadata files for architectures that no longer exist in the repository.
-   * This method queries existing Package index assets using the DAO and deletes those for architectures
-   * not present in the current set of architectures.
-   *
-   * @param currentArchitectures the set of architectures currently in the repository (from KV store)
    */
-  private void removeStaleArchitectureMetadata(final Collection<String> currentArchitectures) {
+  private void removeStaleArchitectureMetadata(final String distribution, final String component, final Collection<String> currentArchitectures) {
     log.debug("Checking for stale architecture metadata in repository: {}", getRepository().getName());
 
-    AptContentFacet aptFacet = content();
-    String dist = aptFacet.getDistribution();
-    String pathPattern = "/dists/" + dist + "/main/binary-%";
+    String pathPattern = "/dists/" + distribution + "/" + component + "/binary-%";
+    Pattern extractPattern = Pattern.compile("^/dists/" + distribution + "/" + component + "/binary-([^/]+)/");
+    removeStaleMetadata(
+        pathPattern,
+        extractPattern,
+        currentArchitectures,
+        staleArch -> "dists/" + distribution + "/" + component + "/binary-" + staleArch + "/",
+        "architecture"
+    );
+  }
 
-    // Browse all Package index assets using DAO and extract unique architectures
-    // Note: We use a high limit (1000) because realistically there are only ~3-15 architectures
-    // with 3 files each (Packages, Packages.gz, Packages.bz2), so ~9-45 files total
+  /**
+   * Removes component metadata for components that no longer exist in the given distribution.
+   */
+  private void removeStaleComponentMetadata(final String distribution, final Collection<String> currentComponents) {
+    log.debug("Checking for stale component metadata in repository: {}", getRepository().getName());
+
+    String pathPattern = "/dists/" + distribution + "/%";
+    Pattern extractPattern = Pattern.compile("^/dists/" + distribution + "/([^/]+)/");
+    removeStaleMetadata(
+        pathPattern,
+        extractPattern,
+        currentComponents,
+        staleComponent -> "dists/" + distribution + "/" + staleComponent + "/",
+        "component"
+    );
+  }
+
+  /**
+   * Removes distribution metadata for distributions that no longer exist in the repository.
+   */
+  private void removeStaleDistributionMetadata(final Collection<String> currentDistributions) {
+    log.debug("Checking for stale distribution metadata in repository: {}", getRepository().getName());
+
+    String pathPattern = "/dists/%";
+    Pattern extractPattern = Pattern.compile("^/dists/([^/]+)/");
+
+    removeStaleMetadata(
+        pathPattern,
+        extractPattern,
+        currentDistributions,
+        staleDist -> "dists/" + staleDist + "/",
+        "distribution"
+    );
+  }
+
+  /**
+   * Generic stale-metadata removal: browses assets matching the given path pattern, extracts an
+   * identifier from each asset path using the first capturing group of {@code extractPattern}, and
+   * deletes assets under the prefix corresponding to any identifier not present in
+   * {@code currentValues}.
+   *
+   * @param pathPattern     the asset path pattern to browse (SQL-like, e.g. "/dists/bullseye/%")
+   * @param extractPattern  regex whose first capturing group extracts the relevant identifier
+   *                        (architecture, component, or distribution) from an asset path
+   * @param currentValues   the set of values currently expected (from KV store)
+   * @param prefixResolver  function mapping a stale identifier to the asset path prefix to delete
+   * @param label           human-readable label for logging
+   */
+  private void removeStaleMetadata(
+      final String pathPattern,
+      final Pattern extractPattern,
+      final Collection<String> currentValues,
+      final Function<String, String> prefixResolver,
+      final String label) {
+
+    AptContentFacet aptFacet = content();
+
     AptAssetStore aptAssetStore = (AptAssetStore) ((AptContentFacetImpl) aptFacet).stores().assetStore;
     Continuation<Asset> assets = aptAssetStore.browsePackageIndexAssets(
         aptFacet.contentRepositoryId(),
@@ -361,23 +396,31 @@ public class AptHostedMetadataFacet
         null,
         pathPattern);
 
-    Set<String> storedArchitectures = assets.stream()
-        .map(asset -> extractArchitectureFromPath(asset.path(), dist))
+    Set<String> storedValues = assets.stream()
+        .map(asset -> extractGroup(extractPattern, asset.path()))
         .filter(Objects::nonNull)
         .collect(Collectors.toSet());
 
-    // Delete Package index files for architectures not in current set
-    for (String storedArch : storedArchitectures) {
-      if (!currentArchitectures.contains(storedArch)) {
-        log.info("Removing stale Package index metadata for architecture '{}' in repository: {}",
-            storedArch, getRepository().getName());
-        aptFacet.deleteAssetsByPrefix(normalizeAssetPath("dists/" + dist + "/main/binary-" + storedArch + "/"));
+    for (String storedValue : storedValues) {
+      if (!currentValues.contains(storedValue)) {
+        log.info("Removing stale {} metadata for '{}' in repository: {}",
+            label, storedValue, getRepository().getName());
+        aptFacet.deleteAssetsByPrefix(normalizeAssetPath(prefixResolver.apply(storedValue)));
       }
     }
   }
 
+  /**
+   * Applies the given regex to the path and returns the first capturing group, or null if no match.
+   */
+  private static String extractGroup(final Pattern pattern, final String path) {
+    Matcher matcher = pattern.matcher(path);
+    return matcher.find() ? matcher.group(1) : null;
+  }
+
   private String buildReleaseFile(
       final String distribution,
+      final Iterable<String> components,
       final Collection<String> architectures,
       final String md5,
       final String sha256)
@@ -385,30 +428,24 @@ public class AptHostedMetadataFacet
     String date = DateFormatUtils.format(new Date(), PATTERN_RFC1123, TimeZone.getTimeZone("GMT"));
     Paragraph p = new Paragraph(Arrays.asList(
         new ControlFile.ControlField("Suite", distribution),
-        new ControlFile.ControlField("Codename", distribution), new ControlFile.ControlField("Components", "main"),
+        new ControlFile.ControlField("Codename", distribution),
+        new ControlFile.ControlField("Components", String.join(" ", components)),
         new ControlFile.ControlField("Date", date),
         new ControlFile.ControlField("Architectures", String.join(StringUtils.SPACE, architectures)),
         new ControlFile.ControlField("SHA256", sha256), new ControlFile.ControlField("MD5Sum", md5)));
     return p.toString();
   }
 
-  private String mainBinaryPrefix() {
-    String dist = content().getDistribution();
-    return "dists/" + dist + "/main/binary-";
-  }
-
-  private String releaseIndexName(final String name) {
-    String dist = content().getDistribution();
+  private String releaseIndexName(final String dist, final String name) {
     return "dists/" + dist + "/" + name;
   }
 
-  private String packageIndexName(final String arch, final String ext) {
-    String dist = content().getDistribution();
-    return "dists/" + dist + "/main/binary-" + arch + "/Packages" + ext;
+  private String packageIndexName(final String dist, final String component, final String arch, final String ext) {
+    return "dists/" + dist + "/" + component + "/binary-" + arch + "/Packages" + ext;
   }
 
-  private String packageRelativeIndexName(final String arch, final String ext) {
-    return "main/binary-" + arch + "/Packages" + ext;
+  private String packageRelativeIndexName(final String component, final String arch, final String ext) {
+    return component + "/binary-" + arch + "/Packages" + ext;
   }
 
   private void addSignatureItem(
@@ -431,21 +468,25 @@ public class AptHostedMetadataFacet
 
   private void storePackageIndexFiles(
       final AptContentFacet aptFacet,
-      final String arch,
+      final String distribution,
+      final String component,
+      final String architecture,
       final CompressingTempFileStore.FileMetadata metadata,
       final StringBuilder md5Builder,
       final StringBuilder sha256Builder) throws IOException
   {
-    putPackageIndexWithSignatures(aptFacet, arch, StringUtils.EMPTY, metadata.plainSupplier(),
+    putPackageIndexWithSignatures(aptFacet, distribution, component, architecture, StringUtils.EMPTY, metadata.plainSupplier(),
         metadata.plainSize(), AptMimeTypes.TEXT, md5Builder, sha256Builder);
-    putPackageIndexWithSignatures(aptFacet, arch, GZ, metadata.gzSupplier(),
+    putPackageIndexWithSignatures(aptFacet, distribution, component, architecture, GZ, metadata.gzSupplier(),
         metadata.gzSize(), AptMimeTypes.GZIP, md5Builder, sha256Builder);
-    putPackageIndexWithSignatures(aptFacet, arch, BZ2, metadata.bzSupplier(),
+    putPackageIndexWithSignatures(aptFacet, distribution, component, architecture, BZ2, metadata.bzSupplier(),
         metadata.bzSize(), AptMimeTypes.BZIP, md5Builder, sha256Builder);
   }
 
   private void putPackageIndexWithSignatures(
       final AptContentFacet aptFacet,
+      final String distro,
+      final String component,
       final String arch,
       final String extension,
       final org.sonatype.nexus.common.io.InputStreamSupplier streamSupplier,
@@ -455,10 +496,10 @@ public class AptHostedMetadataFacet
       final StringBuilder sha256Builder) throws IOException
   {
     FluentAsset asset = aptFacet.put(
-        packageIndexName(arch, extension),
+        packageIndexName(distro, component, arch, extension),
         new StreamPayload(streamSupplier, size, mimeType));
-    addSignatureItem(md5Builder, MD5, asset, packageRelativeIndexName(arch, extension));
-    addSignatureItem(sha256Builder, SHA256, asset, packageRelativeIndexName(arch, extension));
+    addSignatureItem(md5Builder, MD5, asset, packageRelativeIndexName(component, arch, extension));
+    addSignatureItem(sha256Builder, SHA256, asset, packageRelativeIndexName(component, arch, extension));
   }
 
   private AptContentFacet content() {

--- a/public/common/components/formats/nexus-repository-apt/src/main/java/org/sonatype/nexus/repository/apt/internal/AptFacetHelper.java
+++ b/public/common/components/formats/nexus-repository-apt/src/main/java/org/sonatype/nexus/repository/apt/internal/AptFacetHelper.java
@@ -16,6 +16,7 @@ import java.util.List;
 
 import org.sonatype.nexus.common.hash.HashAlgorithm;
 import org.sonatype.nexus.repository.apt.internal.debian.ControlFile;
+import org.sonatype.nexus.repository.apt.internal.debian.PackageInfo;
 import org.sonatype.nexus.repository.apt.internal.snapshot.SnapshotItem;
 import org.sonatype.nexus.repository.apt.internal.snapshot.SnapshotItem.ContentSpecifier;
 import org.sonatype.nexus.repository.browse.node.BrowsePath;
@@ -50,14 +51,6 @@ public class AptFacetHelper
   private static final String PACKAGE_PATH = "dists/%s/%s/binary-%s/%s";
 
   private static final String ASSET_PATH = "pool/%s/%s/%s";
-
-  private static final String MISSED_VALUE_MESSAGE = "Control file doesn't contain '%s' field.";
-
-  private static final String PACKAGE = "Package";
-
-  private static final String VERSION = "Version";
-
-  private static final String ARCHITECTURE = "Architecture";
 
   /**
    * Returns list of the release indexes specifiers
@@ -173,17 +166,11 @@ public class AptFacetHelper
    * @param controlFile - is a representation of Debian control file content.
    * @return - e.g. 'pool/n/nano/nano_2.9.3-2_amd64.deb'
    */
-  public static String buildAssetPath(final ControlFile controlFile) {
-    String name = getValueFromControlFile(controlFile, PACKAGE);
-    String version = getValueFromControlFile(controlFile, VERSION);
-    String architecture = getValueFromControlFile(controlFile, ARCHITECTURE);
+  public static String buildAssetPath(final PackageInfo packageInfo) {
+    String name = packageInfo.getPackageName();
+    String version = packageInfo.getVersion();;
+    String architecture = packageInfo.getArchitecture();
     return buildAssetPath(name, version, architecture);
-  }
-
-  private static String getValueFromControlFile(final ControlFile controlFile, final String fieldName) {
-    return controlFile.getField(fieldName)
-        .map(f -> f.value)
-        .orElseThrow(() -> new IllegalStateException(String.format(MISSED_VALUE_MESSAGE, fieldName)));
   }
 
   /**

--- a/public/common/components/formats/nexus-repository-apt/src/main/java/org/sonatype/nexus/repository/apt/internal/AptProperties.java
+++ b/public/common/components/formats/nexus-repository-apt/src/main/java/org/sonatype/nexus/repository/apt/internal/AptProperties.java
@@ -35,6 +35,14 @@ public final class AptProperties
 
   public static final String P_PACKAGE_VERSION = "package_version";
 
+  public static final String P_DISTRIBUTION = "distribution";
+
+  public static final String P_DISTRIBUTION_HELP_TEXT = "Comma-separated codenames (e.g. `trixie,forky`). If left blank, repository settings will be used.";
+
+  public static final String P_COMPONENT = "component";
+
+  public static final String P_COMPONENT_HELP_TEXT = "Component name (e.g. `main`, `contrib` or `non-free`). If left blank, `main` will be used.";
+
   // Apt supported metadata archive file extensions
   public static final String GZ = ".gz";
 

--- a/public/common/components/formats/nexus-repository-apt/src/main/java/org/sonatype/nexus/repository/apt/internal/debian/PackageInfo.java
+++ b/public/common/components/formats/nexus-repository-apt/src/main/java/org/sonatype/nexus/repository/apt/internal/debian/PackageInfo.java
@@ -25,6 +25,10 @@ public class PackageInfo
 
   private final ControlFile controlFile;
 
+  private String distribution = null;
+
+  private String component = null;
+
   public PackageInfo(final ControlFile controlFile) {
     this.controlFile = controlFile;
   }
@@ -45,7 +49,24 @@ public class PackageInfo
     return getField(ARCHITECTURE_FIELD);
   }
 
+  public String getDistribution() {
+    return this.distribution;
+  }
+
+  public String getComponent() {
+    return this.component;
+  }
+
   private String getField(final String fieldName) {
     return controlFile.getField(fieldName).map(f -> f.value).get();
   }
+
+  public void setDistribution(String value) {
+    this.distribution = value;
+  }
+
+  public void setComponent(String value) {
+    this.component = value;
+  }
+
 }

--- a/public/common/components/formats/nexus-repository-apt/src/main/java/org/sonatype/nexus/repository/apt/internal/hosted/CompressingTempFileStore.java
+++ b/public/common/components/formats/nexus-repository-apt/src/main/java/org/sonatype/nexus/repository/apt/internal/hosted/CompressingTempFileStore.java
@@ -28,7 +28,6 @@ import org.sonatype.goodies.common.ComponentSupport;
 import org.sonatype.nexus.common.io.InputStreamSupplier;
 
 import com.google.common.base.Charsets;
-import com.google.common.collect.Maps;
 import org.apache.commons.compress.compressors.bzip2.BZip2CompressorOutputStream;
 import org.apache.commons.io.output.CountingOutputStream;
 import org.bouncycastle.util.io.TeeOutputStream;
@@ -42,9 +41,9 @@ public class CompressingTempFileStore
     extends ComponentSupport
     implements AutoCloseable
 {
-  private final Map<String, FileHolder> holdersByKey = new HashMap<>();
+  private final Map<DistComponentArchKey, FileHolder> holdersByKey = new HashMap<>();
 
-  public Writer openOutput(final String key) {
+  public Writer openOutput(final DistComponentArchKey key) {
     try {
       if (holdersByKey.containsKey(key)) {
         throw new IllegalStateException("Output already opened");
@@ -61,8 +60,25 @@ public class CompressingTempFileStore
     }
   }
 
-  public Map<String, FileMetadata> getFiles() {
-    return Maps.transformValues(holdersByKey, holder -> new FileMetadata(holder));
+  public boolean isEmpty() {
+    return holdersByKey.isEmpty();
+  }
+
+  public Map<String, Map<String, Map<String, FileMetadata>>> getFiles() {
+    
+    Map<String, Map<String, Map<String, FileMetadata>>> filesByDistComponentAndArch = new HashMap<>();
+
+    for (Map.Entry<DistComponentArchKey, FileHolder> entry : holdersByKey.entrySet()) {
+      DistComponentArchKey key = entry.getKey();
+      FileHolder holder = entry.getValue();
+
+      filesByDistComponentAndArch
+          .computeIfAbsent(key.getDistribution(), k -> new HashMap<>())
+          .computeIfAbsent(key.getComponent(), k -> new HashMap<>())
+          .put(key.getArchitecture(), new FileMetadata(holder));
+    }
+
+    return filesByDistComponentAndArch;
   }
 
   public void close() {
@@ -84,6 +100,32 @@ public class CompressingTempFileStore
     }
     catch (IOException e) { // NOSONAR
       paths.add(path);
+    }
+  }
+
+  public static class DistComponentArchKey {
+    private final String distribution;
+
+    private final String component;
+
+    private final String architecture;
+
+    public DistComponentArchKey(final String distribution, final String component, final String architecture) {
+      this.distribution = distribution;
+      this.component = component;
+      this.architecture = architecture;
+    }
+
+    public String getDistribution() {
+      return distribution;
+    }
+
+    public String getComponent() {
+      return component;
+    }
+
+    public String getArchitecture() {
+      return architecture;
     }
   }
 

--- a/public/common/components/formats/nexus-repository-apt/src/main/java/org/sonatype/nexus/repository/apt/rest/AptProxyRepositoriesAttributes.java
+++ b/public/common/components/formats/nexus-repository-apt/src/main/java/org/sonatype/nexus/repository/apt/rest/AptProxyRepositoriesAttributes.java
@@ -24,7 +24,7 @@ import javax.validation.constraints.NotEmpty;
  */
 public class AptProxyRepositoriesAttributes
 {
-  @ApiModelProperty(value = "Distribution to fetch", example = "bionic")
+  @ApiModelProperty(value = "Distribution to fetch", example = "trixie")
   @NotEmpty
   private final String distribution;
 

--- a/public/common/components/formats/nexus-repository-raw/src/main/java/org/sonatype/nexus/repository/raw/RawUploadHandlerSupport.java
+++ b/public/common/components/formats/nexus-repository-raw/src/main/java/org/sonatype/nexus/repository/raw/RawUploadHandlerSupport.java
@@ -151,8 +151,7 @@ public abstract class RawUploadHandlerSupport
   public UploadDefinition getDefinition() {
     if (definition == null) {
       definition = getDefinition(RawFormat.NAME, true,
-          singletonList(
-              new UploadFieldDefinition(DIRECTORY, DIRECTORY_HELP_TEXT, false, Type.STRING, FIELD_GROUP_NAME)),
+          singletonList(new UploadFieldDefinition(DIRECTORY, DIRECTORY_HELP_TEXT, false, Type.STRING, FIELD_GROUP_NAME)),
           singletonList(new UploadFieldDefinition(FILENAME, false, Type.STRING)),
           new UploadRegexMap("(.*)", FILENAME));
     }

--- a/public/common/components/nexus-coreui-plugin/src/frontend/src/components/pages/browse/Upload/UploadDetails.testdata.js
+++ b/public/common/components/nexus-coreui-plugin/src/frontend/src/components/pages/browse/Upload/UploadDetails.testdata.js
@@ -223,6 +223,31 @@ const rawUploadDefinition = {
   assetFields: []
 };
 
+const aptUploadDefinition = {
+  uiUpload: true,
+  multipleUpload: true,
+  format: 'apt',
+  componentFields: [
+    {
+      displayName: 'Distribution',
+      helpText: null,
+      name: 'distribution',
+      optional: true,
+      type: 'STRING',
+      group: null
+    },
+    {
+      displayName: 'Component',
+      helpText: null,
+      name: 'component',
+      optional: true,
+      type: 'STRING',
+      group: null
+    }
+  ],
+  assetFields: []
+};
+
 export const sampleUploadDefinitions = {
   data: {
     result: {
@@ -233,6 +258,7 @@ export const sampleUploadDefinitions = {
         regexUploadDefinition,
         mavenUploadDefinition,
         rawUploadDefinition,
+        aptUploadDefinition,
         uiUploadDisabledUploadDefinition
       ]
     }

--- a/public/common/components/nexus-coreui-plugin/src/frontend/src/constants/pages/admin/repository/RepositoriesStrings.jsx
+++ b/public/common/components/nexus-coreui-plugin/src/frontend/src/constants/pages/admin/repository/RepositoriesStrings.jsx
@@ -176,7 +176,7 @@ export default {
         CAPTION: 'APT Settings',
         DISTRIBUTION: {
           LABEL: 'Distribution',
-          SUBLABEL: 'Distribution to fetch (e.g., bionic)'
+          SUBLABEL: 'Distribution Codename (e.g., trixie)'
         },
         FLAT: {
           LABEL: 'Flat',

--- a/public/common/components/nexus-coreui-plugin/src/main/resources/static/rapture/NX/coreui/app/PluginStrings.js
+++ b/public/common/components/nexus-coreui-plugin/src/main/resources/static/rapture/NX/coreui/app/PluginStrings.js
@@ -444,7 +444,7 @@ Ext.define('NX.coreui.app.PluginStrings', {
     Repository_Facet_YumHostedFacet_DeployPolicy_PermissiveItem: 'Permissive',
     Repository_Facet_AptFacet_Title: 'APT Settings',
     Repository_Facet_AptFacet_Distribution_FieldLabel: 'Distribution',
-    Repository_Facet_AptFacet_Distribution_HelpText: 'Distribution to fetch e.g. bionic',
+    Repository_Facet_AptFacet_Distribution_HelpText: 'Distribution codename. e.g. trixie',
     Repository_Facet_AptFacet_Flat_FieldLabel: 'Flat',
     Repository_Facet_AptFacet_Flat_HelpText: 'Is this repository flat?',
     Repository_Facet_AptSigningFacet_Keypair_FieldLabel: 'Signing Key',


### PR DESCRIPTION
Adds support for specifying APT distributions and components during package uploads. Updates metadata generation, package indexing, stale metadata cleanup, upload definitions, and UI text to support multi-distribution and multi-component repositories while preserving existing defaults.

Fix #309  #223