### PR TITLE
apt: add distribution and component upload metadata

### DIFF
--- a/public/common/components/formats/nexus-repository-apt/src/main/java/org/sonatype/nexus/repository/apt/AptUploadHandlerSupport.java
+++ b/public/common/components/formats/nexus-repository-apt/src/main/java/org/sonatype/nexus/repository/apt/AptUploadHandlerSupport.java
@@ -14,13 +14,22 @@ package org.sonatype.nexus.repository.apt;
 
 import java.util.Collections;
 import java.util.Set;
+import java.util.Arrays;
 
 import org.sonatype.nexus.repository.Repository;
 import org.sonatype.nexus.repository.rest.UploadDefinitionExtension;
 import org.sonatype.nexus.repository.security.ContentPermissionChecker;
 import org.sonatype.nexus.repository.security.VariableResolverAdapter;
 import org.sonatype.nexus.repository.upload.UploadDefinition;
+import org.sonatype.nexus.repository.upload.UploadFieldDefinition;
+import org.sonatype.nexus.repository.upload.UploadFieldDefinition.Type;
 import org.sonatype.nexus.repository.upload.UploadHandlerSupport;
+
+
+import static org.sonatype.nexus.repository.apt.internal.AptProperties.P_DISTRIBUTION;
+import static org.sonatype.nexus.repository.apt.internal.AptProperties.P_DISTRIBUTION_HELP_TEXT;
+import static org.sonatype.nexus.repository.apt.internal.AptProperties.P_COMPONENT;
+import static org.sonatype.nexus.repository.apt.internal.AptProperties.P_COMPONENT_HELP_TEXT;
 
 /**
  * Common base for an Apt upload handlers
@@ -53,7 +62,12 @@ public abstract class AptUploadHandlerSupport
   @Override
   public UploadDefinition getDefinition() {
     if (definition == null) {
-      definition = getDefinition(AptFormat.NAME, false);
+      definition = getDefinition(AptFormat.NAME, false,
+          Arrays.asList(),
+          Arrays.asList(new UploadFieldDefinition(P_DISTRIBUTION, P_DISTRIBUTION_HELP_TEXT, true, Type.STRING), 
+          new UploadFieldDefinition(P_COMPONENT, P_COMPONENT_HELP_TEXT, true, Type.STRING)),
+          null
+      );
     }
     return definition;
   }

--- a/public/common/components/formats/nexus-repository-apt/src/main/java/org/sonatype/nexus/repository/apt/api/AptHostedRepositoriesAttributes.java
+++ b/public/common/components/formats/nexus-repository-apt/src/main/java/org/sonatype/nexus/repository/apt/api/AptHostedRepositoriesAttributes.java
@@ -28,7 +28,7 @@ public class AptHostedRepositoriesAttributes
       "Defines the distribution path used in metadata structure (e.g., dists/{distribution}/Release). " +
       "Clients must configure this exact distribution name in their APT sources.",
       example = "bionic",
-      required = true)
+      required = false)
   @NotEmpty
   protected final String distribution;
 

--- a/public/common/components/formats/nexus-repository-apt/src/main/java/org/sonatype/nexus/repository/apt/datastore/AptUploadHandler.java
+++ b/public/common/components/formats/nexus-repository-apt/src/main/java/org/sonatype/nexus/repository/apt/datastore/AptUploadHandler.java
@@ -25,7 +25,6 @@ import org.sonatype.nexus.repository.apt.AptUploadHandlerSupport;
 import org.sonatype.nexus.repository.apt.datastore.internal.hosted.AptHostedFacet;
 import org.sonatype.nexus.repository.apt.internal.AptFacetHelper;
 import org.sonatype.nexus.repository.apt.internal.AptPackageParser;
-import org.sonatype.nexus.repository.apt.internal.debian.ControlFile;
 import org.sonatype.nexus.repository.apt.internal.debian.PackageInfo;
 import org.sonatype.nexus.repository.importtask.ImportFileConfiguration;
 import org.sonatype.nexus.repository.importtask.ImportStreamConfiguration;
@@ -44,8 +43,10 @@ import org.sonatype.nexus.repository.view.payloads.TempBlobPayload;
 import org.springframework.beans.factory.annotation.Qualifier;
 
 import static org.apache.commons.lang3.StringUtils.prependIfMissing;
+import static org.sonatype.nexus.repository.apt.internal.AptProperties.P_COMPONENT;
+import static org.sonatype.nexus.repository.apt.internal.AptProperties.P_DISTRIBUTION;
+
 import org.springframework.stereotype.Component;
-import org.springframework.beans.factory.annotation.Qualifier;
 
 /**
  * Support for uploading an Apt components via UI
@@ -70,15 +71,18 @@ public class AptUploadHandler
   public UploadResponse handle(final Repository repository, final ComponentUpload upload) throws IOException {
     AptContentFacet aptContentFacet = repository.facet(AptContentFacet.class);
     AptHostedFacet hostedFacet = repository.facet(AptHostedFacet.class);
+    String component = upload.getAssetUploads().get(0).getField(P_COMPONENT);
+    String distribution = upload.getAssetUploads().get(0).getField(P_DISTRIBUTION);
     PartPayload payload = upload.getAssetUploads().get(0).getPayload();
     try (TempBlob tempBlob = aptContentFacet.getTempBlob(payload)) {
-      ControlFile controlFile = AptPackageParser
-          .parsePackageInfo(tempBlob)
-          .getControlFile();
-      String assetPath = AptFacetHelper.buildAssetPath(controlFile);
+      PackageInfo packageInfo = AptPackageParser
+          .parsePackageInfo(tempBlob);
+      packageInfo.setComponent(component);
+      packageInfo.setDistribution(distribution);
+      String assetPath = AptFacetHelper.buildAssetPath(packageInfo);
       doValidation(repository, prependIfMissing(assetPath, "/"));
       Content content = hostedFacet
-          .put(assetPath, payload, new PackageInfo(controlFile))
+          .put(assetPath, payload, packageInfo)
           .markAsCached(payload)
           .download();
       return new UploadResponse(Collections.singletonList(content), Collections.singletonList(assetPath));
@@ -99,13 +103,12 @@ public class AptUploadHandler
 
     Payload payload = new PathPayload(file.toPath(), Files.probeContentType(file.toPath()));
     try (TempBlob tempBlob = aptContentFacet.getTempBlob(payload)) {
-      ControlFile controlFile = AptPackageParser
-          .parsePackageInfo(tempBlob)
-          .getControlFile();
-      String assetPath = AptFacetHelper.buildAssetPath(controlFile);
+      PackageInfo packageInfo = AptPackageParser
+          .parsePackageInfo(tempBlob);
+      String assetPath = AptFacetHelper.buildAssetPath(packageInfo);
       doValidation(repository, prependIfMissing(assetPath, "/"));
       return hostedFacet
-          .put(assetPath, payload, new PackageInfo(controlFile))
+          .put(assetPath, payload, packageInfo)
           .markAsCached(payload)
           .download();
     }
@@ -118,14 +121,13 @@ public class AptUploadHandler
     AptHostedFacet hostedFacet = repository.facet(AptHostedFacet.class);
 
     try (TempBlob tempBlob = aptContentFacet.getTempBlob(configuration.getInputStream(), null)) {
-      ControlFile controlFile = AptPackageParser
-          .parsePackageInfo(tempBlob)
-          .getControlFile();
-      String assetPath = AptFacetHelper.buildAssetPath(controlFile);
+      PackageInfo packageInfo = AptPackageParser
+          .parsePackageInfo(tempBlob);
+      String assetPath = AptFacetHelper.buildAssetPath(packageInfo);
       doValidation(repository, prependIfMissing(assetPath, "/"));
       Payload payload = new TempBlobPayload(tempBlob, null);
       return hostedFacet
-          .put(assetPath, payload, new PackageInfo(controlFile))
+          .put(assetPath, payload, packageInfo)
           .markAsCached(payload)
           .download();
     }

--- a/public/common/components/formats/nexus-repository-apt/src/main/java/org/sonatype/nexus/repository/apt/datastore/internal/AptContentFacetImpl.java
+++ b/public/common/components/formats/nexus-repository-apt/src/main/java/org/sonatype/nexus/repository/apt/datastore/internal/AptContentFacetImpl.java
@@ -74,6 +74,7 @@ import static org.sonatype.nexus.repository.apt.internal.AptProperties.P_DISTRIB
 import static org.sonatype.nexus.repository.apt.internal.AptProperties.P_INDEX_SECTION;
 import static org.sonatype.nexus.repository.apt.internal.AptProperties.P_PACKAGE_NAME;
 import static org.sonatype.nexus.repository.apt.internal.AptProperties.P_PACKAGE_VERSION;
+import org.sonatype.nexus.common.hash.HashAlgorithm;
 
 /**
  * Apt content facet
@@ -170,12 +171,10 @@ public class AptContentFacetImpl
       final Payload payload,
       @Nullable final PackageInfo packageInfo) throws IOException
   {
-    String normalizedPath = normalizeAssetPath(path);
-
     try (TempBlob tempBlob = blobs().ingest(payload, AptFacetHelper.hashAlgorithms)) {
-      return isDebPackageContentType(normalizedPath)
-          ? findOrCreateDebAsset(normalizedPath, tempBlob, packageInfo)
-          : findOrCreateMetadataAsset(tempBlob, normalizedPath);
+      return isDebPackageContentType(path)
+          ? findOrCreateDebAsset(path, tempBlob, packageInfo)
+          : findOrCreateMetadataAsset(tempBlob, path);
     }
   }
 
@@ -240,15 +239,33 @@ public class AptContentFacetImpl
 
     // Check if asset already exists with CacheInfo (from upstream passthrough)
     Optional<FluentAsset> existing = assets().path(normalizedPath).find();
-    boolean hadCacheInfo = existing.isPresent() &&
-        existing.get().attributes().contains(CacheInfo.CACHE);
+    boolean hadCacheInfo = false;
+    boolean contentChanged = true;
+    FluentAsset asset = null;
+    if (existing.isPresent()) {
+      asset = existing.get();
+      hadCacheInfo = asset.attributes().contains(CacheInfo.CACHE);
 
-    // Save the asset with new blob
-    FluentAsset asset = assets()
+    contentChanged = asset.blob()
+        .map(existingBlob -> {
+          String existingSha256 = existingBlob.checksums().get(HashAlgorithm.SHA256.name());
+          String newSha256 = tempBlob.getHashes().get(HashAlgorithm.SHA256).toString();
+          return existingSha256 == null || !existingSha256.equals(newSha256);
+        })
+        .orElse(true);
+    }
+
+    if (contentChanged || asset == null) {
+      // Save the asset with new blob
+      log.debug("Metadata asset changed, updating blob: {}", path);
+      asset = assets()
         .path(normalizedPath)
         .blob(tempBlob)
         .save();
-
+    } else {
+      log.debug("Metadata asset unchanged, skipping blob update: {}", path);
+    }
+    
     // For generated metadata (proxy signing mode):
     // 1. Clear CacheInfo if it exists (from upstream passthrough)
     // 2. Always set lastModified to NOW (as millis) for proper staleness tracking

--- a/public/common/components/formats/nexus-repository-apt/src/main/java/org/sonatype/nexus/repository/apt/datastore/internal/AptContentFacetImpl.java
+++ b/public/common/components/formats/nexus-repository-apt/src/main/java/org/sonatype/nexus/repository/apt/datastore/internal/AptContentFacetImpl.java
@@ -69,6 +69,8 @@ import static org.sonatype.nexus.repository.apt.debian.Utils.isDebPackageContent
 import static org.sonatype.nexus.repository.apt.internal.AptFacetHelper.normalizeAssetPath;
 import static org.sonatype.nexus.repository.apt.internal.AptProperties.DEB;
 import static org.sonatype.nexus.repository.apt.internal.AptProperties.P_ARCHITECTURE;
+import static org.sonatype.nexus.repository.apt.internal.AptProperties.P_COMPONENT;
+import static org.sonatype.nexus.repository.apt.internal.AptProperties.P_DISTRIBUTION;
 import static org.sonatype.nexus.repository.apt.internal.AptProperties.P_INDEX_SECTION;
 import static org.sonatype.nexus.repository.apt.internal.AptProperties.P_PACKAGE_NAME;
 import static org.sonatype.nexus.repository.apt.internal.AptProperties.P_PACKAGE_VERSION;
@@ -204,6 +206,12 @@ public class AptContentFacetImpl
     formatAttributes.put(P_ARCHITECTURE, info.getArchitecture());
     formatAttributes.put(P_PACKAGE_NAME, info.getPackageName());
     formatAttributes.put(P_PACKAGE_VERSION, info.getVersion());
+    if(info.getDistribution()!=null) {
+      formatAttributes.put(P_DISTRIBUTION, info.getDistribution());
+    }
+    if(info.getComponent()!=null) {
+      formatAttributes.put(P_COMPONENT, info.getComponent());
+    }
     formatAttributes.put(P_INDEX_SECTION, buildIndexSection(controlFile, asset));
 
     FormatAttributesUtils.setFormatAttributes(asset, formatAttributes);

--- a/public/common/components/formats/nexus-repository-apt/src/main/java/org/sonatype/nexus/repository/apt/datastore/internal/hosted/AptHostedHandler.java
+++ b/public/common/components/formats/nexus-repository-apt/src/main/java/org/sonatype/nexus/repository/apt/datastore/internal/hosted/AptHostedHandler.java
@@ -20,7 +20,6 @@ import org.sonatype.nexus.repository.apt.datastore.AptContentFacet;
 import org.sonatype.nexus.repository.apt.datastore.internal.metadata.AptMetadataRebuildSchedulerFacet;
 import org.sonatype.nexus.repository.apt.internal.AptFacetHelper;
 import org.sonatype.nexus.repository.apt.internal.AptPackageParser;
-import org.sonatype.nexus.repository.apt.internal.debian.ControlFile;
 import org.sonatype.nexus.repository.apt.internal.debian.PackageInfo;
 import org.sonatype.nexus.repository.apt.internal.snapshot.AptSnapshotHandler;
 import org.sonatype.nexus.repository.http.HttpResponses;
@@ -41,6 +40,9 @@ import static org.sonatype.nexus.repository.http.HttpMethods.GET;
 import static org.sonatype.nexus.repository.http.HttpMethods.HEAD;
 import static org.sonatype.nexus.repository.http.HttpMethods.POST;
 import org.springframework.stereotype.Component;
+
+import static org.sonatype.nexus.repository.apt.internal.AptProperties.P_DISTRIBUTION;
+import static org.sonatype.nexus.repository.apt.internal.AptProperties.P_COMPONENT;
 
 /**
  * Apt handlers
@@ -91,16 +93,19 @@ public class AptHostedHandler
     }
     else if (StringUtils.isBlank(path)) {
       final Payload payload = context.getRequest().getPayload();
+      final String distribution = context.getRequest().getParameters().get(P_DISTRIBUTION);
+      final String component = context.getRequest().getParameters().get(P_COMPONENT);
       try (TempBlob tempBlob = contentFacet.getTempBlob(payload)) {
-        ControlFile controlFile = AptPackageParser
-            .parsePackageInfo(tempBlob)
-            .getControlFile();
-        String assetPath = AptFacetHelper.buildAssetPath(controlFile);
+        PackageInfo packageInfo = AptPackageParser
+            .parsePackageInfo(tempBlob);
+        packageInfo.setDistribution(distribution);
+        packageInfo.setComponent(component);
+        String assetPath = AptFacetHelper.buildAssetPath(packageInfo);
         long payloadSize = payload.getSize();
         String contentType = payload.getContentType();
 
         hostedFacet.put(assetPath, new StreamPayload(tempBlob, payloadSize, contentType),
-            new PackageInfo(controlFile));
+            packageInfo);
       }
       return HttpResponses.created();
     }

--- a/public/common/components/formats/nexus-repository-apt/src/main/java/org/sonatype/nexus/repository/apt/datastore/internal/hosted/AptHostedHandler.java
+++ b/public/common/components/formats/nexus-repository-apt/src/main/java/org/sonatype/nexus/repository/apt/datastore/internal/hosted/AptHostedHandler.java
@@ -116,7 +116,13 @@ public class AptHostedHandler
 
   private boolean isMetadataRebuildRequired(final String path, final AptContentFacet contentFacet) {
     if (path.startsWith("dists")) {
-      String inReleasePath = "dists/" + contentFacet.getDistribution() + "/" + INRELEASE;
+      // Rebuild if metadata for the requested distribution is missing.
+      String[] parts = path.split("/");
+      if (parts.length < 2) {
+        return false;
+      }
+      String distribution = parts[1];
+      String inReleasePath = "dists/" + distribution + "/" + INRELEASE;
       return contentFacet.get(inReleasePath).isEmpty();
     }
     return false;

--- a/public/common/components/formats/nexus-repository-apt/src/main/java/org/sonatype/nexus/repository/apt/datastore/internal/hosted/metadata/AptHostedMetadataFacet.java
+++ b/public/common/components/formats/nexus-repository-apt/src/main/java/org/sonatype/nexus/repository/apt/datastore/internal/hosted/metadata/AptHostedMetadataFacet.java
@@ -16,20 +16,18 @@ import java.io.IOException;
 import java.io.Writer;
 import java.time.Duration;
 import java.time.OffsetDateTime;
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.Collections;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
-import java.util.Objects;
+import java.util.Map.Entry;
 import java.util.Optional;
 import java.util.Set;
-import java.util.stream.Collectors;
 
 import org.springframework.beans.factory.annotation.Autowired;
 
 import org.sonatype.nexus.common.entity.Continuation;
+import org.sonatype.nexus.common.entity.Continuations;
 import org.sonatype.nexus.common.cooperation2.Cooperation2Factory;
 import org.sonatype.nexus.common.time.Clock;
 import org.sonatype.nexus.repository.Facet.Exposed;
@@ -40,6 +38,8 @@ import org.sonatype.nexus.repository.apt.datastore.internal.metadata.AptMetadata
 import org.sonatype.nexus.repository.apt.datastore.internal.store.AptAssetStore;
 import org.sonatype.nexus.repository.apt.internal.gpg.AptSigningFacet;
 import org.sonatype.nexus.repository.apt.internal.hosted.CompressingTempFileStore;
+import org.sonatype.nexus.repository.apt.internal.hosted.CompressingTempFileStore.DistComponentArchKey;
+import org.sonatype.nexus.repository.apt.internal.hosted.CompressingTempFileStore.FileMetadata;
 import org.sonatype.nexus.repository.content.Asset;
 import org.sonatype.nexus.repository.content.fluent.FluentAsset;
 import org.sonatype.nexus.repository.view.Content;
@@ -55,9 +55,10 @@ import org.springframework.stereotype.Component;
 import static org.sonatype.nexus.repository.apt.internal.AptFacetHelper.normalizeAssetPath;
 import static org.sonatype.nexus.repository.apt.internal.AptProperties.P_ARCHITECTURE;
 import static org.sonatype.nexus.repository.apt.internal.AptProperties.P_INDEX_SECTION;
-import static org.sonatype.nexus.repository.apt.internal.ReleaseName.INRELEASE;
-import static org.sonatype.nexus.repository.apt.internal.ReleaseName.RELEASE;
-import static org.sonatype.nexus.repository.apt.internal.ReleaseName.RELEASE_GPG;
+import static org.sonatype.nexus.repository.apt.internal.AptProperties.P_PACKAGE_NAME;
+import static org.sonatype.nexus.repository.apt.internal.AptProperties.P_DISTRIBUTION;
+import static org.sonatype.nexus.repository.apt.internal.AptProperties.P_COMPONENT;
+import static org.sonatype.nexus.repository.apt.internal.AptProperties.P_PACKAGE_VERSION;
 
 /**
  * Apt metadata facet. Holds the logic for metadata recalculation.
@@ -90,38 +91,47 @@ public class AptHostedMetadataFacet
     AptContentFacet aptFacet = content();
     AptSigningFacet signingFacet = signing();
 
-    StringBuilder sha256Builder = new StringBuilder();
-    StringBuilder md5Builder = new StringBuilder();
     String releaseFile = null;
-    Set<String> currentArchitectures = null;
-    String distribution = aptFacet.getDistribution();
-    try (CompressingTempFileStore store = buildPackageIndexes()) {
-      for (Map.Entry<String, CompressingTempFileStore.FileMetadata> entry : store.getFiles().entrySet()) {
-        storePackageIndexFiles(aptFacet, distribution, DEFAULT_COMPONENT, entry.getKey(), entry.getValue(), md5Builder,
-            sha256Builder);
-      }
-      if (!store.getFiles().isEmpty()) {
-        currentArchitectures = store.getFiles().keySet();
-        releaseFile = buildReleaseFile(
-            distribution,
-            Collections.singletonList(DEFAULT_COMPONENT),
-            currentArchitectures,
-            md5Builder.toString(),
-            sha256Builder.toString());
-      }
-      else {
-        // No packages in repository - remove all metadata
-        log.info("No packages found in repository: {} - removing all metadata", getRepository().getName());
-        removeAllMetadata();
+    FluentAsset releaseFileAsset = null;
+    try (CompressingTempFileStore store = buildPackageIndexes(aptFacet)) {
+
+      // Loop on each discovered distributions, components & architectures.
+      Map<String, Map<String, Map<String, FileMetadata>>> pkgIndexes = store.getFiles();
+      for (Entry<String, Map<String, Map<String, FileMetadata>>> distEntry : pkgIndexes.entrySet()) {
+        final String distribution = distEntry.getKey();
+        Set<String> currentArchitectures = new HashSet<>();
+
+        // Create package index per architecture.
+        StringBuilder sha256Builder = new StringBuilder();
+        StringBuilder md5Builder = new StringBuilder();
+        for (Entry<String, Map<String, FileMetadata>> componentEntry : distEntry.getValue().entrySet()) {
+
+          String component = componentEntry.getKey();
+          for (Entry<String, FileMetadata> archEntry : componentEntry.getValue().entrySet()) {
+            storePackageIndexFiles(aptFacet, distribution, component, archEntry.getKey(), archEntry.getValue(), md5Builder, sha256Builder);
+          }
+
+          // Collect valid architectures
+          currentArchitectures.addAll(componentEntry.getValue().keySet());
+          
+        }
+        
+        Set<String> currentComponents = distEntry.getValue().keySet();
+        if (!currentArchitectures.isEmpty()) {
+          releaseFile = buildReleaseFile(
+              distribution,
+              currentComponents,
+              currentArchitectures,
+              md5Builder.toString(),
+              sha256Builder.toString());
+          releaseFileAsset = generateReleaseFiles(distribution, releaseFile, aptFacet, signingFacet);
+        } 
+
       }
 
-    }
-    FluentAsset releaseFileAsset =
-        generateReleaseFiles(distribution, releaseFile, aptFacet, signingFacet);
+      // Single cleanup pass: anything under dists/ untouched by this rebuild is stale.
+      removeStaleMetadata(rebuildStart);
 
-    // Clean up stale architecture metadata after successful rebuild
-    if (currentArchitectures != null && !currentArchitectures.isEmpty()) {
-      removeStaleArchitectureMetadata(currentArchitectures);
     }
 
     OffsetDateTime finishTime = clock.clusterTime();
@@ -130,9 +140,9 @@ public class AptHostedMetadataFacet
     return Optional.ofNullable(releaseFileAsset).map(FluentAsset::download).orElse(null);
   }
 
-  private CompressingTempFileStore buildPackageIndexes() throws IOException {
+  private CompressingTempFileStore buildPackageIndexes(AptContentFacet aptFacet) throws IOException {
     CompressingTempFileStore result = new CompressingTempFileStore();
-    Map<String, Writer> writersByArch = new HashMap<>();
+    Map<DistComponentArchKey, Writer> writersMap = new HashMap<>();
     boolean ok = false;
     try {
       final List<Map<String, Object>> allPackagesMetadata = keyValue()
@@ -140,34 +150,43 @@ public class AptHostedMetadataFacet
           .map(this::deserialize)
           .toList();
 
-      // Group packages by architecture only - we need to preserve all versions
-      Map<String, List<Map<String, Object>>> packagesByArch = new HashMap<>();
+      // Single-pass deduplication and grouping by architecture
+      // Deduplicate by (distribution, component, architecture, package name, version)
+      // to handle KV store duplicate entries
+      Map<DistComponentArchKey, Set<String>> packageNameSeen = new HashMap<>();
       for (Map<String, Object> pkg : allPackagesMetadata) {
+        Object distributionObj = pkg.get(P_DISTRIBUTION);
+        Object componentObj = pkg.get(P_COMPONENT);
+        Object packageNameObj = pkg.get(P_PACKAGE_NAME);
         Object architectureObj = pkg.get(P_ARCHITECTURE);
+        Object versionObj = pkg.get(P_PACKAGE_VERSION);
         if (architectureObj == null) {
           log.warn("Skipping package with missing architecture: {}", pkg);
           continue;
         }
-        String architecture = architectureObj.toString();
-        packagesByArch
-            .computeIfAbsent(architecture, k -> new ArrayList<>())
-            .add(pkg);
-      }
 
-      int totalPackages = packagesByArch.values()
-          .stream()
-          .mapToInt(List::size)
-          .sum();
-      log.debug("Building package indexes: {} architectures, {} packages from {} KV entries",
-          packagesByArch.size(), totalPackages, allPackagesMetadata.size());
+        // Handle package in multiple distro
+        String distributions = distributionObj != null ? distributionObj.toString() : aptFacet.getDistribution();
+        for (String distribution : distributions.split(",")) {
+          distribution = distribution.trim();
 
-      // Write package indexes for each architecture
-      for (Map.Entry<String, List<Map<String, Object>>> archEntry : packagesByArch.entrySet()) {
-        String architecture = archEntry.getKey();
-        List<Map<String, Object>> packagesForArch = archEntry.getValue();
-        Writer outWriter = writersByArch.computeIfAbsent(architecture, result::openOutput);
+          // When component is not defined, default to "main" for backward compatibility
+          String component = componentObj != null ? componentObj.toString() : "main";
+          String architecture = architectureObj.toString();
+          String packageName = packageNameObj.toString();
+          String version = versionObj != null ? versionObj.toString() : "";
 
-        for (Map<String, Object> pkg : packagesForArch) {
+          // Check if duplicate — now based on name + version, not just name
+          DistComponentArchKey key = new DistComponentArchKey(distribution, component, architecture);
+          String nameVersionKey = packageName + "_" + version;
+          if (packageNameSeen.computeIfAbsent(key, k -> new HashSet<>()).contains(nameVersionKey)) {
+            log.warn("Skipping duplicate package name/version: {}", pkg);
+            continue;
+          }
+          packageNameSeen.get(key).add(nameVersionKey);
+
+          // Write package details to Package Indexes
+          Writer outWriter = writersMap.computeIfAbsent(key, result::openOutput);
           final String indexSection = (String) pkg.get(P_INDEX_SECTION);
           outWriter.write(indexSection);
           outWriter.write("\n\n");
@@ -176,7 +195,7 @@ public class AptHostedMetadataFacet
       ok = true;
     }
     finally {
-      for (Writer writer : writersByArch.values()) {
+      for (Writer writer : writersMap.values()) {
         IOUtils.closeQuietly(writer, null);
       }
 
@@ -188,99 +207,48 @@ public class AptHostedMetadataFacet
   }
 
   /**
-   * Removes all metadata files (Packages indexes and Release files).
-   * This is called before rebuilding to ensure stale architectures are cleaned up.
+   * Removes any metadata assets under dists/ that were not touched during this rebuild
+   * (i.e. their lastUpdated timestamp is older than the rebuild start time).
    */
-  private void removeAllMetadata() {
-    log.debug("Removing all metadata files for repository: {}", getRepository().getName());
-    AptContentFacet aptFacet = content();
-
-    // Remove all Package index files (binary-*/Packages*)
-    try {
-      aptFacet.deleteAssetsByPrefix(normalizeAssetPath(buildMainBinaryPrefix()));
-    }
-    catch (Exception e) {
-      log.warn("Failed to delete package index files", e);
-    }
-
-    // Remove Release files
-    String dist = aptFacet.getDistribution();
-    deleteReleaseFile(aptFacet, dist, RELEASE);
-    deleteReleaseFile(aptFacet, dist, INRELEASE);
-    deleteReleaseFile(aptFacet, dist, RELEASE_GPG);
-  }
-
-  private void deleteReleaseFile(final AptContentFacet aptFacet, final String dist, final String fileName) {
-    try {
-      aptFacet.assets()
-          .path(normalizeAssetPath("dists/" + dist + "/" + fileName))
-          .find()
-          .ifPresent(FluentAsset::delete);
-    }
-    catch (Exception e) {
-      log.warn("Failed to delete release file: {}", fileName, e);
-    }
-  }
-
-  /**
-   * Extracts the architecture from a Package index asset path.
-   * Path format: /dists/{distribution}/main/binary-{arch}/Packages{extension}
-   *
-   * @param path the asset path
-   * @param distribution the distribution name
-   * @return the architecture or null if path doesn't match expected format
-   */
-  private String extractArchitectureFromPath(final String path, final String distribution) {
-    String pattern = "/dists/" + distribution + "/main/binary-";
-    if (path.startsWith(pattern)) {
-      String remainder = path.substring(pattern.length());
-      int slashIndex = remainder.indexOf('/');
-      if (slashIndex > 0) {
-        return remainder.substring(0, slashIndex);
-      }
-    }
-    return null;
-  }
-
-  /**
-   * Builds the path prefix for main binary package index files.
-   *
-   * @return the path prefix (e.g., "dists/jammy/main/binary-")
-   */
-  private String buildMainBinaryPrefix() {
-    return String.format("dists/%s/main/binary-", content().getDistribution());
-  }
-
-  private void removeStaleArchitectureMetadata(final Collection<String> currentArchitectures) {
-    log.debug("Checking for stale architecture metadata in repository: {}", getRepository().getName());
+  private void removeStaleMetadata(final OffsetDateTime removeOlderThan) {
+    log.debug("Checking for stale metadata older than {} in repository: {}",
+        removeOlderThan, getRepository().getName());
 
     AptContentFacet aptFacet = content();
-    String dist = aptFacet.getDistribution();
-    String pathPattern = "/dists/" + dist + "/main/binary-%";
-
-    // Browse all Package index assets using DAO and extract unique architectures
-    // Note: We use a high limit (1000) because realistically there are only ~3-15 architectures
-    // with 3 files each (Packages, Packages.gz, Packages.bz2), so ~9-45 files total
     AptAssetStore aptAssetStore = (AptAssetStore) ((AptContentFacetImpl) aptFacet).stores().assetStore;
+
+    int deletedCount = 0;
+    int totalAssets = 0;
+
     Continuation<Asset> assets = aptAssetStore.browsePackageIndexAssets(
         aptFacet.contentRepositoryId(),
-        1000,
+        Continuations.BROWSE_LIMIT,
         null,
-        pathPattern);
+        "/dists/%");
 
-    Set<String> storedArchitectures = assets.stream()
-        .map(asset -> extractArchitectureFromPath(asset.path(), dist))
-        .filter(Objects::nonNull)
-        .collect(Collectors.toSet());
-
-    // Delete Package index files for architectures not in current set
-    for (String storedArch : storedArchitectures) {
-      if (!currentArchitectures.contains(storedArch)) {
-        log.info("Removing stale Package index metadata for architecture '{}' in repository: {}",
-            storedArch, getRepository().getName());
-        aptFacet.deleteAssetsByPrefix(normalizeAssetPath("dists/" + dist + "/main/binary-" + storedArch + "/"));
+    while (!assets.isEmpty()) {
+      for (Asset asset : assets) {
+        totalAssets++;
+        if (asset.lastUpdated().isBefore(removeOlderThan)) {
+          log.info("Removing stale metadata asset '{}' (last updated {}) in repository: {}",
+              asset.path(), asset.lastUpdated(), getRepository().getName());
+          aptAssetStore.deleteAsset(asset);
+          deletedCount++;
+        }
+        else {
+          log.debug("Asset '{}' is current (last updated {}) - skipping", asset.path(), asset.lastUpdated());
+        }
       }
+
+      assets = aptAssetStore.browsePackageIndexAssets(
+          aptFacet.contentRepositoryId(),
+          Continuations.BROWSE_LIMIT,
+          assets.nextContinuationToken(),
+          "/dists/%");
     }
+
+    log.debug("Stale metadata cleanup complete: {} of {} assets removed in repository: {}",
+        deletedCount, totalAssets, getRepository().getName());
   }
 
   private AptSigningFacet signing() {

--- a/public/common/components/formats/nexus-repository-apt/src/main/java/org/sonatype/nexus/repository/apt/datastore/internal/metadata/AptMetadataFacetSupport.java
+++ b/public/common/components/formats/nexus-repository-apt/src/main/java/org/sonatype/nexus/repository/apt/datastore/internal/metadata/AptMetadataFacetSupport.java
@@ -14,6 +14,8 @@ package org.sonatype.nexus.repository.apt.datastore.internal.metadata;
 
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.time.Duration;
 import java.util.Arrays;
 import java.util.Collection;
@@ -57,6 +59,7 @@ import static org.sonatype.nexus.common.hash.HashAlgorithm.MD5;
 import static org.sonatype.nexus.common.hash.HashAlgorithm.SHA256;
 import static org.sonatype.nexus.repository.apt.internal.AptProperties.BZ2;
 import static org.sonatype.nexus.repository.apt.internal.AptProperties.GZ;
+import static org.sonatype.nexus.repository.apt.internal.AptProperties.XZ;
 import static org.apache.http.protocol.HttpDateGenerator.PATTERN_RFC1123;
 import static org.sonatype.nexus.repository.apt.internal.ReleaseName.INRELEASE;
 import static org.sonatype.nexus.repository.apt.internal.ReleaseName.RELEASE;
@@ -324,12 +327,27 @@ public abstract class AptMetadataFacetSupport
       final StringBuilder md5Builder,
       final StringBuilder sha256Builder) throws IOException
   {
-    putPackageIndexWithSignatures(aptFacet, distribution, component, arch, StringUtils.EMPTY, metadata.plainSupplier(),
-        metadata.plainSize(), AptMimeTypes.TEXT, md5Builder, sha256Builder);
-    putPackageIndexWithSignatures(aptFacet, distribution, component, arch, GZ, metadata.gzSupplier(),
-        metadata.gzSize(), AptMimeTypes.GZIP, md5Builder, sha256Builder);
-    putPackageIndexWithSignatures(aptFacet, distribution, component, arch, BZ2, metadata.bzSupplier(),
-        metadata.bzSize(), AptMimeTypes.BZIP, md5Builder, sha256Builder);
+    Path plain = metadata.plainFile();
+    putPackageIndexWithSignatures(aptFacet, distribution, component, arch, StringUtils.EMPTY,
+        () -> Files.newInputStream(plain),Files.size(plain), AptMimeTypes.TEXT, md5Builder, sha256Builder);
+
+    Path gz = metadata.compressToTemp(GZ);
+    try {
+      putPackageIndexWithSignatures(aptFacet, distribution, component, arch, GZ,
+          () -> Files.newInputStream(gz), Files.size(gz), AptMimeTypes.GZIP, md5Builder, sha256Builder);
+    }
+    finally {
+      Files.deleteIfExists(gz);
+    }
+
+    Path xz = metadata.compressToTemp(XZ);
+    try {
+      putPackageIndexWithSignatures(aptFacet, distribution, component, arch, XZ,
+          () -> Files.newInputStream(xz), Files.size(xz), AptMimeTypes.XZ, md5Builder, sha256Builder);
+    }
+    finally {
+      Files.deleteIfExists(xz);
+    }
   }
 
   /**

--- a/public/common/components/formats/nexus-repository-apt/src/main/java/org/sonatype/nexus/repository/apt/datastore/internal/metadata/AptMetadataFacetSupport.java
+++ b/public/common/components/formats/nexus-repository-apt/src/main/java/org/sonatype/nexus/repository/apt/datastore/internal/metadata/AptMetadataFacetSupport.java
@@ -210,19 +210,6 @@ public abstract class AptMetadataFacetSupport
   protected abstract Content doRebuildMetadata() throws IOException;
 
   /**
-   * Stores a package index file.
-   * Both hosted and proxy use content().put() for storing package indices.
-   *
-   * @param path asset path
-   * @param payload content payload
-   * @return the stored asset
-   * @throws IOException if storage fails
-   */
-  protected FluentAsset storePackageIndex(final String path, final StreamPayload payload) throws IOException {
-    return content().put(path, payload);
-  }
-
-  /**
    * Adds a signature item (checksum + size + filename) to the Release file builder.
    * Used to populate MD5Sum and SHA256 sections of the Release file.
    *

--- a/public/common/components/formats/nexus-repository-apt/src/main/java/org/sonatype/nexus/repository/apt/datastore/internal/proxy/metadata/AptProxyMetadataFacet.java
+++ b/public/common/components/formats/nexus-repository-apt/src/main/java/org/sonatype/nexus/repository/apt/datastore/internal/proxy/metadata/AptProxyMetadataFacet.java
@@ -26,6 +26,7 @@ import java.util.HashSet;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Map.Entry;
 import java.util.Optional;
 import java.util.Set;
 import java.util.TreeSet;
@@ -49,6 +50,8 @@ import org.sonatype.nexus.repository.apt.internal.debian.ControlFile.Paragraph;
 import org.sonatype.nexus.repository.apt.internal.debian.ControlFileParser;
 import org.sonatype.nexus.repository.apt.internal.gpg.AptSigningFacet;
 import org.sonatype.nexus.repository.apt.internal.hosted.CompressingTempFileStore;
+import org.sonatype.nexus.repository.apt.internal.hosted.CompressingTempFileStore.DistComponentArchKey;
+import org.sonatype.nexus.repository.apt.internal.hosted.CompressingTempFileStore.FileMetadata;
 import org.sonatype.nexus.repository.cache.CacheController;
 import org.sonatype.nexus.repository.cache.CacheInfo;
 import org.sonatype.nexus.repository.content.fluent.FluentAsset;
@@ -117,13 +120,6 @@ public class AptProxyMetadataFacet
    * Length of hash prefix to display in debug logs (first 8 hex characters).
    */
   private static final int HASH_PREFIX_LENGTH = 8;
-
-  /**
-   * Separator for composite keys (component|architecture) in CompressingTempFileStore.
-   */
-  private static final String SLICE_KEY_SEPARATOR = "|";
-
-  private static final String SLICE_KEY_SEPARATOR_PATTERN = "\\|";
 
   private static final Comparator<PackageEntry> STABLE_COMPARATOR = Comparator
       .comparing(PackageEntry::packageName)
@@ -699,7 +695,7 @@ public class AptProxyMetadataFacet
               slice.architecture());
 
           // Write with deterministic ordering - use composite key for store
-          String storeKey = slice.component() + SLICE_KEY_SEPARATOR + slice.architecture();
+          DistComponentArchKey storeKey = new DistComponentArchKey(distribution, slice.component(), slice.architecture());
           Writer writer = writersBySlice.computeIfAbsent(slice, k -> store.openOutput(storeKey));
           for (PackageEntry entry : sortedEntries) {
             writer.write(entry.indexSection());
@@ -713,13 +709,17 @@ public class AptProxyMetadataFacet
         }
       }
 
-      // Store package index files - parse composite key to get component and arch
-      for (Map.Entry<String, CompressingTempFileStore.FileMetadata> entry : store.getFiles().entrySet()) {
-        String[] parts = entry.getKey().split(SLICE_KEY_SEPARATOR_PATTERN);
-        String component = parts[0];
-        String arch = parts[1];
-        storePackageIndexFiles(aptFacet, distribution, component, arch, entry.getValue(),
+      // Store package index files
+      Map<String, Map<String, Map<String, FileMetadata>>> pkgIndexes = store.getFiles();
+      for (Entry<String, Map<String, Map<String, FileMetadata>>> distEntry : pkgIndexes.entrySet()) {
+          for (Entry<String, Map<String, FileMetadata>> componentEntry : distEntry.getValue().entrySet()) {
+          String component = componentEntry.getKey();
+          for (Entry<String, FileMetadata> archEntry : componentEntry.getValue().entrySet()) {
+            String arch = archEntry.getKey();
+            storePackageIndexFiles(aptFacet, distribution, component, arch, archEntry.getValue(),
             md5Builder, sha256Builder);
+          }
+        }
       }
     }
 
@@ -784,7 +784,7 @@ public class AptProxyMetadataFacet
 
           architectures.add(arch);
           // Use composite key with DEFAULT_COMPONENT
-          String storeKey = DEFAULT_COMPONENT + SLICE_KEY_SEPARATOR + arch;
+          DistComponentArchKey storeKey = new DistComponentArchKey(distribution, DEFAULT_COMPONENT, arch);
           Writer writer = writersByArch.computeIfAbsent(arch, k -> store.openOutput(storeKey));
           for (PackageEntry entry : sortedEntries) {
             writer.write(entry.indexSection());
@@ -798,13 +798,17 @@ public class AptProxyMetadataFacet
         }
       }
 
-      // Store package index files - parse composite key to get component and arch
-      for (Map.Entry<String, CompressingTempFileStore.FileMetadata> entry : store.getFiles().entrySet()) {
-        String[] parts = entry.getKey().split(SLICE_KEY_SEPARATOR_PATTERN);
-        String component = parts[0];
-        String arch = parts[1];
-        storePackageIndexFiles(aptFacet, distribution, component, arch, entry.getValue(),
+      // Store package index files
+      Map<String, Map<String, Map<String, FileMetadata>>> pkgIndexes = store.getFiles();
+      for (Entry<String, Map<String, Map<String, FileMetadata>>> distEntry : pkgIndexes.entrySet()) {
+          for (Entry<String, Map<String, FileMetadata>> componentEntry : distEntry.getValue().entrySet()) {
+          String component = componentEntry.getKey();
+          for (Entry<String, FileMetadata> archEntry : componentEntry.getValue().entrySet()) {
+            String arch = archEntry.getKey();
+            storePackageIndexFiles(aptFacet, distribution, component, arch, archEntry.getValue(),
             md5Builder, sha256Builder);
+          }
+        }
       }
     }
 

--- a/public/common/components/formats/nexus-repository-apt/src/main/java/org/sonatype/nexus/repository/apt/internal/AptFacetHelper.java
+++ b/public/common/components/formats/nexus-repository-apt/src/main/java/org/sonatype/nexus/repository/apt/internal/AptFacetHelper.java
@@ -15,7 +15,7 @@ package org.sonatype.nexus.repository.apt.internal;
 import java.util.List;
 
 import org.sonatype.nexus.common.hash.HashAlgorithm;
-import org.sonatype.nexus.repository.apt.internal.debian.ControlFile;
+import org.sonatype.nexus.repository.apt.internal.debian.PackageInfo;
 import org.sonatype.nexus.repository.apt.internal.snapshot.SnapshotItem;
 import org.sonatype.nexus.repository.apt.internal.snapshot.SnapshotItem.ContentSpecifier;
 import org.sonatype.nexus.repository.browse.node.BrowsePath;
@@ -50,14 +50,6 @@ public class AptFacetHelper
   private static final String PACKAGE_PATH = "dists/%s/%s/binary-%s/%s";
 
   private static final String ASSET_PATH = "pool/%s/%s/%s";
-
-  private static final String MISSED_VALUE_MESSAGE = "Control file doesn't contain '%s' field.";
-
-  private static final String PACKAGE = "Package";
-
-  private static final String VERSION = "Version";
-
-  private static final String ARCHITECTURE = "Architecture";
 
   /**
    * Returns list of the release indexes specifiers
@@ -173,17 +165,11 @@ public class AptFacetHelper
    * @param controlFile - is a representation of Debian control file content.
    * @return - e.g. 'pool/n/nano/nano_2.9.3-2_amd64.deb'
    */
-  public static String buildAssetPath(final ControlFile controlFile) {
-    String name = getValueFromControlFile(controlFile, PACKAGE);
-    String version = getValueFromControlFile(controlFile, VERSION);
-    String architecture = getValueFromControlFile(controlFile, ARCHITECTURE);
+  public static String buildAssetPath(final PackageInfo packageInfo) {
+    String name = packageInfo.getPackageName();
+    String version = packageInfo.getVersion();;
+    String architecture = packageInfo.getArchitecture();
     return buildAssetPath(name, version, architecture);
-  }
-
-  private static String getValueFromControlFile(final ControlFile controlFile, final String fieldName) {
-    return controlFile.getField(fieldName)
-        .map(f -> f.value)
-        .orElseThrow(() -> new IllegalStateException(String.format(MISSED_VALUE_MESSAGE, fieldName)));
   }
 
   /**

--- a/public/common/components/formats/nexus-repository-apt/src/main/java/org/sonatype/nexus/repository/apt/internal/AptProperties.java
+++ b/public/common/components/formats/nexus-repository-apt/src/main/java/org/sonatype/nexus/repository/apt/internal/AptProperties.java
@@ -35,6 +35,14 @@ public final class AptProperties
 
   public static final String P_PACKAGE_VERSION = "package_version";
 
+  public static final String P_DISTRIBUTION = "distribution";
+
+  public static final String P_DISTRIBUTION_HELP_TEXT = "Comma-separated codenames (e.g. `trixie,forky`). If left blank, repository settings will be used.";
+
+  public static final String P_COMPONENT = "component";
+
+  public static final String P_COMPONENT_HELP_TEXT = "Component name (e.g. `main`, `contrib` or `non-free`). If left blank, `main` will be used.";
+
   // Apt supported metadata archive file extensions
   public static final String GZ = ".gz";
 

--- a/public/common/components/formats/nexus-repository-apt/src/main/java/org/sonatype/nexus/repository/apt/internal/AptProperties.java
+++ b/public/common/components/formats/nexus-repository-apt/src/main/java/org/sonatype/nexus/repository/apt/internal/AptProperties.java
@@ -47,4 +47,6 @@ public final class AptProperties
   public static final String GZ = ".gz";
 
   public static final String BZ2 = ".bz2";
+
+  public static final String XZ = ".xz";
 }

--- a/public/common/components/formats/nexus-repository-apt/src/main/java/org/sonatype/nexus/repository/apt/internal/debian/PackageInfo.java
+++ b/public/common/components/formats/nexus-repository-apt/src/main/java/org/sonatype/nexus/repository/apt/internal/debian/PackageInfo.java
@@ -25,6 +25,10 @@ public class PackageInfo
 
   private final ControlFile controlFile;
 
+  private String distribution = null;
+
+  private String component = null;
+
   public PackageInfo(final ControlFile controlFile) {
     this.controlFile = controlFile;
   }
@@ -45,7 +49,24 @@ public class PackageInfo
     return getField(ARCHITECTURE_FIELD);
   }
 
+  public String getDistribution() {
+    return this.distribution;
+  }
+
+  public String getComponent() {
+    return this.component;
+  }
+
   private String getField(final String fieldName) {
     return controlFile.getField(fieldName).map(f -> f.value).get();
   }
+
+  public void setDistribution(String value) {
+    this.distribution = value;
+  }
+
+  public void setComponent(String value) {
+    this.component = value;
+  }
+
 }

--- a/public/common/components/formats/nexus-repository-apt/src/main/java/org/sonatype/nexus/repository/apt/internal/gpg/AptSigningFacet.java
+++ b/public/common/components/formats/nexus-repository-apt/src/main/java/org/sonatype/nexus/repository/apt/internal/gpg/AptSigningFacet.java
@@ -35,7 +35,11 @@ import com.google.common.annotations.VisibleForTesting;
 import org.apache.commons.io.IOUtils;
 import org.bouncycastle.bcpg.ArmoredOutputStream;
 import org.bouncycastle.bcpg.BCPGOutputStream;
+import org.bouncycastle.openpgp.PGPException;
+import org.bouncycastle.openpgp.PGPPrivateKey;
 import org.bouncycastle.openpgp.PGPPublicKey;
+import org.bouncycastle.openpgp.PGPSecretKey;
+import org.bouncycastle.openpgp.operator.PBESecretKeyDecryptor;
 import org.springframework.beans.factory.config.ConfigurableBeanFactory;
 import org.springframework.context.annotation.Scope;
 import org.springframework.stereotype.Component;
@@ -52,6 +56,9 @@ public class AptSigningFacet
     extends FacetSupport
 {
   public static final String CONFIG_KEY = "aptSigning";
+
+  private volatile PGPPrivateKey cachedPrivateKey;
+  private volatile PGPSecretKey cachedSecretKey;
 
   @VisibleForTesting
   static class Config
@@ -103,13 +110,33 @@ public class AptSigningFacet
     return new Content(new BytesPayload(buffer.toByteArray(), AptMimeTypes.PUBLICKEY));
   }
 
+  private synchronized void ensureKeysLoaded() throws IOException, PGPException {
+    if (cachedPrivateKey == null) {
+      PBESecretKeyDecryptor keyDecryptor = GpgUtils.getSecretKeyDecryptor(config.passphrase);
+      cachedSecretKey = GpgUtils.readSecretKey(config.keypair);
+      cachedPrivateKey = cachedSecretKey.extractPrivateKey(keyDecryptor);
+    }
+  }
+
   public byte[] signInline(final String input) throws IOException {
-    return GpgUtils.signInline(input, config.keypair, config.passphrase);
+    try {
+      ensureKeysLoaded();
+    }
+    catch (PGPException e) {
+      throw new RuntimeException(e); // NOSONAR
+    }
+    return GpgUtils.signInline(input, cachedSecretKey, cachedPrivateKey);
   }
 
   public byte[] signExternal(final String input) throws IOException {
+    try {
+      ensureKeysLoaded();
+    }
+    catch (PGPException e) {
+      throw new RuntimeException(e); // NOSONAR
+    }
     try (InputStream is = IOUtils.toInputStream(input, StandardCharsets.UTF_8)) {
-      return GpgUtils.signExternal(is, config.keypair, config.passphrase);
+      return GpgUtils.signExternal(is, cachedSecretKey, cachedPrivateKey);
     }
   }
 }

--- a/public/common/components/formats/nexus-repository-apt/src/main/java/org/sonatype/nexus/repository/apt/internal/hosted/CompressingTempFileStore.java
+++ b/public/common/components/formats/nexus-repository-apt/src/main/java/org/sonatype/nexus/repository/apt/internal/hosted/CompressingTempFileStore.java
@@ -13,6 +13,7 @@
 package org.sonatype.nexus.repository.apt.internal.hosted;
 
 import java.io.IOException;
+import java.io.OutputStream;
 import java.io.OutputStreamWriter;
 import java.io.UncheckedIOException;
 import java.io.Writer;
@@ -27,14 +28,21 @@ import java.util.zip.GZIPOutputStream;
 import org.sonatype.nexus.common.io.InputStreamSupplier;
 
 import com.google.common.base.Charsets;
+import static org.sonatype.nexus.repository.apt.internal.AptProperties.BZ2;
+import static org.sonatype.nexus.repository.apt.internal.AptProperties.GZ;
+import static org.sonatype.nexus.repository.apt.internal.AptProperties.XZ;
 import org.apache.commons.compress.compressors.bzip2.BZip2CompressorOutputStream;
-import org.apache.commons.io.output.CountingOutputStream;
-import org.bouncycastle.util.io.TeeOutputStream;
+import org.apache.commons.compress.compressors.xz.XZCompressorOutputStream;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 /**
- * Stores a set of temp files, automatically compressing each into a GZIP, BZ2 and plain format.
+ * Stores a set of plain-text temp files keyed by distribution/component/architecture.
+ * Compression (gz/bz2/xz) is intentionally not handled here — callers are expected
+ * to compress from {@link FileMetadata#plainSupplier()} on demand, immediately
+ * consume the compressed temp file, and delete it right after. This avoids holding
+ * multiple compressor instances (particularly XZ/LZMA2, which is memory heavy)
+ * alive at once, and avoids caching compressed variants that may never be read.
  *
  * @since 3.17
  */
@@ -52,10 +60,7 @@ public class CompressingTempFileStore
       }
       FileHolder holder = new FileHolder();
       holdersByKey.put(key, holder);
-      return new OutputStreamWriter(new TeeOutputStream(
-          new TeeOutputStream(new GZIPOutputStream(Files.newOutputStream(holder.gzTempFile)),
-              new BZip2CompressorOutputStream(Files.newOutputStream(holder.bzTempFile))),
-          Files.newOutputStream(holder.plainTempFile)), Charsets.UTF_8);
+      return new OutputStreamWriter(Files.newOutputStream(holder.plainTempFile), Charsets.UTF_8);
     }
     catch (IOException e) {
       throw new UncheckedIOException(e);
@@ -87,8 +92,7 @@ public class CompressingTempFileStore
     List<Path> notDeletedFiles = new LinkedList<>();
 
     for (FileHolder holder : holdersByKey.values()) {
-      deleteFile(holder.bzTempFile, notDeletedFiles);
-      deleteFile(holder.gzTempFile, notDeletedFiles);
+      deleteFile(holder.plainTempFile, notDeletedFiles);
     }
 
     if (!notDeletedFiles.isEmpty()) {
@@ -155,59 +159,59 @@ public class CompressingTempFileStore
 
   public static class FileMetadata
   {
+    /**
+     * Low-memory XZ preset — preset 6 (xz-java default) costs ~100MB per encoder,
+     * preset 9 costs ~700MB+. Index files are text and don't need higher presets.
+     */
+    private static final int XZ_PRESET = 0;
+
     private final FileHolder holder;
 
     private FileMetadata(final FileHolder holder) {
       this.holder = holder;
     }
 
-    public long bzSize() {
-      return holder.bzStream.getByteCount();
+    public Path plainFile() {
+      return holder.plainTempFile;
     }
 
-    public InputStreamSupplier bzSupplier() {
-      return () -> Files.newInputStream(holder.bzTempFile);
+    /**
+     * Compresses the plain file to a new temp file using a single compressor instance.
+     * The caller is responsible for deleting the returned file once it's been consumed.
+     */
+    public Path compressToTemp(final String type) throws IOException {
+      Path tempFile = Files.createTempFile("", "");
+      try (OutputStream fileOut = Files.newOutputStream(tempFile);
+          OutputStream compressorOut = wrap(fileOut, type)) {
+        Files.copy(holder.plainTempFile, compressorOut);
+      }
+      catch (IOException e) {
+        Files.deleteIfExists(tempFile);
+        throw e;
+      }
+      return tempFile;
     }
 
-    public long gzSize() {
-      return holder.gzStream.getByteCount();
-    }
-
-    public InputStreamSupplier gzSupplier() {
-      return () -> Files.newInputStream(holder.gzTempFile);
-    }
-
-    public long plainSize() {
-      return holder.plainStream.getByteCount();
-    }
-
-    public InputStreamSupplier plainSupplier() {
-      return () -> Files.newInputStream(holder.plainTempFile);
+    private static OutputStream wrap(final OutputStream out, final String type) throws IOException {
+      switch (type) {
+        case GZ:
+          return new GZIPOutputStream(out);
+        case BZ2:
+          return new BZip2CompressorOutputStream(out);
+        case XZ:
+          return new XZCompressorOutputStream(out, XZ_PRESET);
+        default:
+          throw new IllegalArgumentException("Unsupported compression type: " + type);
+      }
     }
   }
 
   private static class FileHolder
   {
-    final CountingOutputStream plainStream;
-
     final Path plainTempFile;
 
-    final CountingOutputStream gzStream;
-
-    final Path gzTempFile;
-
-    final CountingOutputStream bzStream;
-
-    final Path bzTempFile;
-
-    public FileHolder() throws IOException {
-      super();
+    FileHolder() throws IOException {
       this.plainTempFile = Files.createTempFile("", "");
-      this.plainStream = new CountingOutputStream(Files.newOutputStream(plainTempFile));
-      this.gzTempFile = Files.createTempFile("", "");
-      this.gzStream = new CountingOutputStream(Files.newOutputStream(gzTempFile));
-      this.bzTempFile = Files.createTempFile("", "");
-      this.bzStream = new CountingOutputStream(Files.newOutputStream(bzTempFile));
     }
   }
 }

--- a/public/common/components/formats/nexus-repository-apt/src/main/java/org/sonatype/nexus/repository/apt/internal/hosted/CompressingTempFileStore.java
+++ b/public/common/components/formats/nexus-repository-apt/src/main/java/org/sonatype/nexus/repository/apt/internal/hosted/CompressingTempFileStore.java
@@ -27,7 +27,6 @@ import java.util.zip.GZIPOutputStream;
 import org.sonatype.nexus.common.io.InputStreamSupplier;
 
 import com.google.common.base.Charsets;
-import com.google.common.collect.Maps;
 import org.apache.commons.compress.compressors.bzip2.BZip2CompressorOutputStream;
 import org.apache.commons.io.output.CountingOutputStream;
 import org.bouncycastle.util.io.TeeOutputStream;
@@ -44,9 +43,9 @@ public class CompressingTempFileStore
 {
   protected final Logger log = LoggerFactory.getLogger(getClass());
 
-  private final Map<String, FileHolder> holdersByKey = new HashMap<>();
+  private final Map<DistComponentArchKey, FileHolder> holdersByKey = new HashMap<>();
 
-  public Writer openOutput(final String key) {
+  public Writer openOutput(final DistComponentArchKey key) {
     try {
       if (holdersByKey.containsKey(key)) {
         throw new IllegalStateException("Output already opened");
@@ -63,8 +62,25 @@ public class CompressingTempFileStore
     }
   }
 
-  public Map<String, FileMetadata> getFiles() {
-    return Maps.transformValues(holdersByKey, holder -> new FileMetadata(holder));
+  public boolean isEmpty() {
+    return holdersByKey.isEmpty();
+  }
+
+  public Map<String, Map<String, Map<String, FileMetadata>>> getFiles() {
+    
+    Map<String, Map<String, Map<String, FileMetadata>>> filesByDistComponentAndArch = new HashMap<>();
+
+    for (Map.Entry<DistComponentArchKey, FileHolder> entry : holdersByKey.entrySet()) {
+      DistComponentArchKey key = entry.getKey();
+      FileHolder holder = entry.getValue();
+
+      filesByDistComponentAndArch
+          .computeIfAbsent(key.getDistribution(), k -> new HashMap<>())
+          .computeIfAbsent(key.getComponent(), k -> new HashMap<>())
+          .put(key.getArchitecture(), new FileMetadata(holder));
+    }
+
+    return filesByDistComponentAndArch;
   }
 
   public void close() {
@@ -86,6 +102,54 @@ public class CompressingTempFileStore
     }
     catch (IOException e) { // NOSONAR
       paths.add(path);
+    }
+  }
+
+  public static class DistComponentArchKey {
+    private final String distribution;
+
+    private final String component;
+
+    private final String architecture;
+
+    public DistComponentArchKey(final String distribution, final String component, final String architecture) {
+      this.distribution = distribution;
+      this.component = component;
+      this.architecture = architecture;
+    }
+
+    public String getDistribution() {
+      return distribution;
+    }
+
+    public String getComponent() {
+      return component;
+    }
+
+    public String getArchitecture() {
+      return architecture;
+    }
+
+    @Override
+    public boolean equals(final Object o) {
+      if (this == o) {
+        return true;
+      }
+      if (!(o instanceof DistComponentArchKey)) {
+        return false;
+      }
+      DistComponentArchKey that = (DistComponentArchKey) o;
+      return distribution.equals(that.distribution)
+          && component.equals(that.component)
+          && architecture.equals(that.architecture);
+    }
+
+    @Override
+    public int hashCode() {
+      int result = distribution.hashCode();
+      result = 31 * result + component.hashCode();
+      result = 31 * result + architecture.hashCode();
+      return result;
     }
   }
 

--- a/public/common/components/formats/nexus-repository-apt/src/test/java/org/sonatype/nexus/repository/apt/datastore/internal/proxy/metadata/AptProxyMetadataFacetTest.java
+++ b/public/common/components/formats/nexus-repository-apt/src/test/java/org/sonatype/nexus/repository/apt/datastore/internal/proxy/metadata/AptProxyMetadataFacetTest.java
@@ -632,51 +632,6 @@ public class AptProxyMetadataFacetTest
   // ==========================================================================
 
   @Test
-  public void testSliceKeySeparator_DefinedCorrectly() throws Exception {
-    Field separatorField = AptProxyMetadataFacet.class.getDeclaredField("SLICE_KEY_SEPARATOR");
-    separatorField.setAccessible(true);
-    String separator = (String) separatorField.get(null);
-
-    assertThat(separator, is("|"));
-  }
-
-  @Test
-  public void testSliceKeySeparatorPattern_EscapedCorrectly() throws Exception {
-    Field patternField = AptProxyMetadataFacet.class.getDeclaredField("SLICE_KEY_SEPARATOR_PATTERN");
-    patternField.setAccessible(true);
-    String pattern = (String) patternField.get(null);
-
-    // Pattern should be escaped for use in split()
-    assertThat(pattern, is("\\|"));
-
-    // Verify it works correctly in split
-    String testKey = "main|amd64";
-    String[] parts = testKey.split(pattern);
-    assertThat(parts.length, is(2));
-    assertThat(parts[0], is("main"));
-    assertThat(parts[1], is("amd64"));
-  }
-
-  @Test
-  public void testCompositeKeyParsing_MultipleComponents() throws Exception {
-    Field patternField = AptProxyMetadataFacet.class.getDeclaredField("SLICE_KEY_SEPARATOR_PATTERN");
-    patternField.setAccessible(true);
-    String pattern = (String) patternField.get(null);
-
-    // Test various component/arch combinations
-    String[] testCases = {
-        "main|amd64", "universe|amd64", "multiverse|arm64", "restricted|i386"
-    };
-
-    for (String testKey : testCases) {
-      String[] parts = testKey.split(pattern);
-      assertThat("Key should split into 2 parts: " + testKey, parts.length, is(2));
-      assertThat("Component should not be empty: " + testKey, parts[0].length() > 0, is(true));
-      assertThat("Architecture should not be empty: " + testKey, parts[1].length() > 0, is(true));
-    }
-  }
-
-  @Test
   public void testSliceRecord_HasComponentAndArchitecture() throws Exception {
     // Find the Slice inner class
     Class<?>[] innerClasses = AptProxyMetadataFacet.class.getDeclaredClasses();

--- a/public/common/components/nexus-coreui-plugin/src/frontend/src/components/pages/browse/Upload/UploadDetails.testdata.js
+++ b/public/common/components/nexus-coreui-plugin/src/frontend/src/components/pages/browse/Upload/UploadDetails.testdata.js
@@ -223,6 +223,31 @@ const rawUploadDefinition = {
   assetFields: []
 };
 
+const aptUploadDefinition = {
+  uiUpload: true,
+  multipleUpload: true,
+  format: 'apt',
+  componentFields: [
+    {
+      displayName: 'Distribution',
+      helpText: null,
+      name: 'distribution',
+      optional: true,
+      type: 'STRING',
+      group: null
+    },
+    {
+      displayName: 'Component',
+      helpText: null,
+      name: 'component',
+      optional: true,
+      type: 'STRING',
+      group: null
+    }
+  ],
+  assetFields: []
+};
+
 export const sampleUploadDefinitions = {
   data: {
     result: {
@@ -233,6 +258,7 @@ export const sampleUploadDefinitions = {
         regexUploadDefinition,
         mavenUploadDefinition,
         rawUploadDefinition,
+        aptUploadDefinition,
         uiUploadDisabledUploadDefinition
       ]
     }

--- a/public/common/components/nexus-repository-services/src/main/java/org/sonatype/nexus/repository/security/GpgUtils.java
+++ b/public/common/components/nexus-repository-services/src/main/java/org/sonatype/nexus/repository/security/GpgUtils.java
@@ -136,12 +136,12 @@ public class GpgUtils
    */
   public static byte[] signExternal(
       final InputStream input,
-      final String secretKey,
-      @Nullable final String passphrase) throws IOException
+      final PGPSecretKey signKey,
+      final PGPPrivateKey privateKey) throws IOException
   {
     ByteArrayOutputStream buffer = new ByteArrayOutputStream();
     try {
-      PGPSignatureGenerator sigGenerator = initPgpSignatureGenerator(secretKey, passphrase, BINARY_DOCUMENT);
+      PGPSignatureGenerator sigGenerator = buildSignatureGenerator(signKey, privateKey, BINARY_DOCUMENT);
       try (ArmoredOutputStream aOut = new ArmoredOutputStream(buffer)) {
         BCPGOutputStream bOut = new BCPGOutputStream(aOut);
         sigGenerator.update(ByteStreams.toByteArray(input));
@@ -164,13 +164,12 @@ public class GpgUtils
    */
   public static byte[] signInline(
       final String input,
-      final String secretKey,
-      final String passphrase) throws IOException
+      final PGPSecretKey signKey,
+      final PGPPrivateKey privateKey) throws IOException
   {
     ByteArrayOutputStream buffer = new ByteArrayOutputStream();
     try {
-      PGPSecretKey signKey = readSecretKey(secretKey);
-      PGPSignatureGenerator sigGenerator = initPgpSignatureGenerator(secretKey, passphrase, CANONICAL_TEXT_DOCUMENT);
+      PGPSignatureGenerator sigGenerator = buildSignatureGenerator(signKey, privateKey, CANONICAL_TEXT_DOCUMENT);
 
       Iterator<String> userIds = signKey.getUserIDs();
       if (userIds.hasNext()) {
@@ -218,7 +217,7 @@ public class GpgUtils
    * @param secretKey the GPG secret/private key.
    * @return the {@link PGPSecretKey} object.
    */
-  private static PGPSecretKey readSecretKey(final String secretKey) throws IOException {
+  public static PGPSecretKey readSecretKey(final String secretKey) throws IOException {
     try (InputStream decoderStream = PGPUtil.getDecoderStream(
         new ByteArrayInputStream(secretKey.getBytes(UTF_8)))) {
       PGPSecretKeyRingCollection pgpSec = new PGPSecretKeyRingCollection(
@@ -243,14 +242,11 @@ public class GpgUtils
     throw new IllegalStateException("Can't find signing key in key ring.");
   }
 
-  private static PGPSignatureGenerator initPgpSignatureGenerator(
-      final String secretKey,
-      final String passphrase,
-      final int pgpSignature) throws IOException, PGPException
+  private static PGPSignatureGenerator buildSignatureGenerator(
+      final PGPSecretKey signKey,
+      final PGPPrivateKey privateKey,
+      final int pgpSignature) throws PGPException
   {
-    PBESecretKeyDecryptor keyDecryptor = getSecretKeyDecryptor(passphrase);
-    PGPSecretKey signKey = readSecretKey(secretKey);
-    PGPPrivateKey privateKey = signKey.extractPrivateKey(keyDecryptor);
     PGPSignatureGenerator sigGenerator = new PGPSignatureGenerator(
         new JcaPGPContentSignerBuilder(signKey.getPublicKey().getAlgorithm(), SHA256)
             .setProvider(BC_PROVIDER));
@@ -258,7 +254,7 @@ public class GpgUtils
     return sigGenerator;
   }
 
-  private static PBESecretKeyDecryptor getSecretKeyDecryptor(final String passphrase) throws PGPException {
+  public static PBESecretKeyDecryptor getSecretKeyDecryptor(final String passphrase) throws PGPException {
     char[] pass = StringUtils.isNotBlank(passphrase) ? passphrase.toCharArray() : EMPTY_PASSPHRASE;
     return new JcePBESecretKeyDecryptorBuilder()
         .setProvider(BC_PROVIDER)


### PR DESCRIPTION
Similar to my other pull request #1032 #1033 But this pull request is rebase for version 3.94.1 Hoping this would make it easier to be merge upstream.

Adds support for specifying APT distributions and components during package uploads. Updates metadata generation, package indexing, stale metadata cleanup, upload definitions, and UI text to support multi-distribution and multi-component repositories while preserving existing defaults.

Fix https://github.com/sonatype/nexus-public/issues/309 https://github.com/sonatype/nexus-public/issues/223