### PR TITLE
fix: return 400 instead of 500 for duplicate userId in POST /v1/security/users

### DIFF
--- a/public/selfhosted/components/api/nexus-api-rest-selfhosted/src/main/java/org/sonatype/nexus/api/rest/selfhosted/user/UserApiResource.java
+++ b/public/selfhosted/components/api/nexus-api-rest-selfhosted/src/main/java/org/sonatype/nexus/api/rest/selfhosted/user/UserApiResource.java
@@ -38,6 +38,7 @@ import org.sonatype.nexus.security.internal.rest.ApiUser;
 import org.sonatype.nexus.security.internal.rest.ApiUserStatus;
 import org.sonatype.nexus.security.role.Role;
 import org.sonatype.nexus.security.role.RoleIdentifier;
+import org.sonatype.nexus.security.user.DuplicateUserException;
 import org.sonatype.nexus.security.user.NoSuchUserManagerException;
 import org.sonatype.nexus.security.user.User;
 import org.sonatype.nexus.security.user.UserManager;
@@ -90,6 +91,10 @@ public class UserApiResource
     try {
       User user = securitySystem.addUser(createUser.toUser(), createUser.getPassword());
       return fromUser(user);
+    }
+    catch (DuplicateUserException e) {
+      log.debug("Unable to create duplicate user: {}", createUser.getUserId(), e);
+      throw createWebException(Status.BAD_REQUEST, "User '" + createUser.getUserId() + "' already exists.");
     }
     catch (NoSuchUserManagerException e) {
       log.error("Unable to locate default usermanager.", e);

--- a/public/selfhosted/components/api/nexus-api-rest-selfhosted/src/test/java/org/sonatype/nexus/api/rest/selfhosted/user/UserApiResourceTest.java
+++ b/public/selfhosted/components/api/nexus-api-rest-selfhosted/src/test/java/org/sonatype/nexus/api/rest/selfhosted/user/UserApiResourceTest.java
@@ -29,6 +29,7 @@ import org.sonatype.nexus.security.internal.rest.ApiUser;
 import org.sonatype.nexus.security.internal.rest.ApiUserStatus;
 import org.sonatype.nexus.security.role.Role;
 import org.sonatype.nexus.security.role.RoleIdentifier;
+import org.sonatype.nexus.security.user.DuplicateUserException;
 import org.sonatype.nexus.security.user.NoSuchUserManagerException;
 import org.sonatype.nexus.security.user.User;
 import org.sonatype.nexus.security.user.UserManager;
@@ -137,6 +138,19 @@ class UserApiResourceTest
     WebApplicationMessageException ex = assertThrows(WebApplicationMessageException.class,
         () -> underTest.createUser(createUser), "Unable to locate source: default");
     assertThat(ex.getResponse().getStatusInfo(), is(Status.NOT_FOUND));
+  }
+
+  @Test
+  void testCreateUser_duplicateUser() throws Exception {
+    User user = createUser();
+    when(securitySystem.addUser(user, "admin123")).thenThrow(new DuplicateUserException(USER_ID));
+
+    ApiCreateUser createUser = new ApiCreateUser(USER_ID, "John", "Smith", "jsmith@example.org", "admin123",
+        ApiUserStatus.disabled, Collections.singleton("nx-admin"));
+
+    WebApplicationMessageException ex = assertThrows(WebApplicationMessageException.class,
+        () -> underTest.createUser(createUser), "User '" + USER_ID + "' already exists.");
+    assertThat(ex.getResponse().getStatusInfo(), is(Status.BAD_REQUEST));
   }
 
   /*


### PR DESCRIPTION
## What

`POST /v1/security/users` returns HTTP 500 `Internal Server Error` with a plain-text `DuplicateUserException` message when a duplicate `userId` is submitted.

## Why

The `DuplicateUserException` thrown by `SecuritySystem.addUser()` is not caught in `UserApiResource.createUser()`, so it escapes as a 500 error.

## Fix

Catch `DuplicateUserException` in `createUser()` and return `400 Bad Request` with a structured JSON message, consistent with how other security endpoints (roles, privileges, content-selectors) handle duplicate resources.

- Added `DuplicateUserException` import
- Added catch block returning 400 BAD_REQUEST
- Added test `testCreateUser_duplicateUser`

Closes #1047